### PR TITLE
test: Add mapping tests

### DIFF
--- a/src/main/kotlin/no/nb/bikube/core/mapper/ItemMapper.kt
+++ b/src/main/kotlin/no/nb/bikube/core/mapper/ItemMapper.kt
@@ -21,13 +21,14 @@ fun mapCollectionsObjectToGenericItem(model: CollectionsObject): Item {
 fun mapCollectionsPartsObjectToGenericItem(
     model: CollectionsPartsReference,
     titleCatalogueId: String?,
-    titleName: String?
+    titleName: String?,
+    materialType: String?
 ): Item {
     return Item(
         catalogueId = model.priRef!!,
         name = model.titleList?.first()?.title,
         date = model.titleList?.first()?.title.let { parseYearOrDate(it?.takeLast(10)) },
-        materialType = null,
+        materialType = materialType,
         titleCatalogueId = titleCatalogueId,
         titleName = titleName,
         digital = model.formatList?.first()?.first { it.lang == "neutral" }?.text == AxiellFormat.DIGITAL.value

--- a/src/main/kotlin/no/nb/bikube/core/model/CollectionsObject.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/CollectionsObject.kt
@@ -15,9 +15,6 @@ data class CollectionsObject(
     @JsonProperty("@priref")
     val priRef: String,
 
-    @JsonProperty("object_number")
-    val objectNumber: String,
-
     @JsonProperty("Title")
     val titleList: List<CollectionsTitle>?,
 
@@ -123,9 +120,6 @@ data class CollectionsPartsReference(
 
     @JsonProperty("group:Title")
     val titleList: List<CollectionsTitle>?,
-
-    @JsonProperty("object_number")
-    val objectNumber: String?,
 
     @JsonProperty("record_type")
     val recordType: List<List<CollectionsLanguageListObject>>?,

--- a/src/main/kotlin/no/nb/bikube/core/model/CollectionsObject.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/CollectionsObject.kt
@@ -12,7 +12,7 @@ data class CollectionsRecordList(
 )
 
 data class CollectionsObject(
-    @JsonProperty("priref")
+    @JsonProperty("@priref")
     val priRef: String,
 
     @JsonProperty("object_number")
@@ -49,8 +49,10 @@ data class CollectionsObject(
     val placeOfPublicationList: List<String>?,
 
     @JsonProperty("Parts")
-    val partsList: List<CollectionsPartsObject>?
-)
+    val partsList: List<CollectionsPartsObject>?,
+
+    @JsonProperty("work.description_type")
+    val workTypeList: List<List<CollectionsLanguageListObject>>?)
 
 data class CollectionsTitle(
     val title: String?
@@ -79,14 +81,14 @@ data class CollectionsPartOfReference(
     @JsonProperty("group:Title")
     val title: List<CollectionsTitle>?,
 
-    @JsonProperty("object_number")
-    val objectNumber: String?,
-
     @JsonProperty("record_type")
     val recordType: List<List<CollectionsLanguageListObject>>?,
 
     @JsonProperty("group:Submedium")
     val subMedium: List<SubMedium>?,
+
+    @JsonProperty("work.description_type")
+    val workTypeList: List<List<CollectionsLanguageListObject>>?
 )
 
 data class SubMedium(

--- a/src/main/kotlin/no/nb/bikube/newspaper/service/AxiellService.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/service/AxiellService.kt
@@ -103,12 +103,14 @@ class AxiellService  (
     fun getItemsForTitle(titleCatalogId: String): Flux<Item> {
         var titleName: String? = null
         var titleId: String? = null
+        var materialType: String? = null
 
         return getSingleCollectionsModel(titleCatalogId)
             .flatMapIterable { it.adlibJson.recordList }
             .flatMapIterable { title ->
                 titleName = title.titleList?.first()?.title
                 titleId = title.priRef
+                materialType = title.subMediumList?.first()?.subMedium
 
                 if (
                     !title.partsList.isNullOrEmpty()
@@ -131,7 +133,12 @@ class AxiellService  (
             }
             .mapNotNull { item ->
                 item.partsReference?.let {
-                    mapCollectionsPartsObjectToGenericItem(item.partsReference, titleCatalogueId = titleId, titleName = titleName)
+                    mapCollectionsPartsObjectToGenericItem(
+                        item.partsReference,
+                        titleCatalogueId = titleId,
+                        titleName = titleName,
+                        materialType = materialType
+                    )
                 }
             }
     }

--- a/src/test/kotlin/no/nb/bikube/core/mapper/ItemMapperTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/mapper/ItemMapperTests.kt
@@ -1,0 +1,50 @@
+package no.nb.bikube.core.mapper
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nb.bikube.core.model.CollectionsModel
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.io.File
+import java.time.LocalDate
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ItemMapperTests {
+    private fun mapper(): ObjectMapper {
+        val mapper = jacksonObjectMapper()
+        // Disable unknown properties as we are not using all fields, and will test for what we need
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        return mapper
+    }
+
+    private val singleItemJson = File("src/test/resources/CollectionsJsonTestFiles/NewspaperItemSingle.json")
+    private val singleItem = mapper().readValue<CollectionsModel>(singleItemJson).adlibJson.recordList.first()
+    private val genericItem = mapCollectionsObjectToGenericItem(singleItem)
+
+    @Test
+    fun `Item mapper should map catalogueId`() { Assertions.assertEquals("5", genericItem.catalogueId) }
+
+    @Test
+    fun `Item mapper should map name`() { Assertions.assertEquals("Bikubeavisen 2012.01.02", genericItem.name) }
+
+    @Test
+    fun `Item mapper should map date`() { Assertions.assertEquals(LocalDate.parse("2012-01-02"), genericItem.date) }
+
+    @Test
+    fun `Item mapper should map material type`() { Assertions.assertEquals("Avis", genericItem.materialType) }
+
+    @Test
+    fun `Item mapper should map title ID`() { Assertions.assertEquals("3", genericItem.titleCatalogueId) }
+
+    @Test
+    fun `Item mapper should map title name`() { Assertions.assertEquals("Bikubeavisen", genericItem.titleName) }
+
+    @Test
+    fun `Item mapper should map if digital`() { Assertions.assertEquals(true, genericItem.digital) }
+
+}

--- a/src/test/kotlin/no/nb/bikube/core/mapper/ItemOnTitleMapperTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/mapper/ItemOnTitleMapperTests.kt
@@ -1,0 +1,105 @@
+package no.nb.bikube.core.mapper
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nb.bikube.core.model.CollectionsModel
+import no.nb.bikube.core.model.Item
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.io.File
+import java.time.LocalDate
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ItemOnTitleMapperTests {
+
+    private fun mapper(): ObjectMapper {
+        val mapper = jacksonObjectMapper()
+        // Disable unknown properties as we are not using all fields, and will test for what we need
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        return mapper
+    }
+
+    private val singleItemJson = File("src/test/resources/CollectionsJsonTestFiles/NewspaperTitleSingle.json")
+    private val singleItem = mapper().readValue<CollectionsModel>(singleItemJson).adlibJson.recordList.first()
+
+    private fun itemList(): List<Item> {
+        val list = mutableListOf<Item>()
+        singleItem.partsList!!.forEach { yearWork ->
+            yearWork.partsReference!!.partsList?.forEach { manifest ->
+                manifest.partsReference!!.partsList?.forEach { item ->
+                    list.add(mapCollectionsPartsObjectToGenericItem(
+                        item.partsReference!!,
+                        singleItem.priRef,
+                        singleItem.titleList!!.first().title,
+                        singleItem.subMediumList!!.first().subMedium
+                    ))
+                }
+            }
+        }
+        return list
+    }
+    private val mappedList = itemList()
+
+    @Test
+    fun `Item-on-title mapper should have all item`() {
+        Assertions.assertEquals(4, mappedList.size)
+    }
+
+    @Test
+    fun `Item-on-title mapper should map catalogueId`() {
+        Assertions.assertEquals("19", mappedList[0].catalogueId)
+        Assertions.assertEquals("21", mappedList[1].catalogueId)
+        Assertions.assertEquals("6", mappedList[2].catalogueId)
+        Assertions.assertEquals("5", mappedList[3].catalogueId)
+    }
+
+    @Test
+    fun `Item-on-title mapper should map names`() {
+        Assertions.assertEquals("Bikubeavisen 2011.01.24", mappedList[0].name)
+        Assertions.assertEquals("Bikubeavisen 2012.01.09", mappedList[1].name)
+        Assertions.assertEquals("Bikubeavisen 2012.01.02", mappedList[2].name)
+        Assertions.assertEquals("Bikubeavisen 2012.01.02", mappedList[3].name)
+    }
+
+    @Test
+    fun `Item-on-title mapper should map dates`() {
+        Assertions.assertEquals(LocalDate.parse("2011-01-24"), mappedList[0].date)
+        Assertions.assertEquals(LocalDate.parse("2012-01-09"), mappedList[1].date)
+        Assertions.assertEquals(LocalDate.parse("2012-01-02"), mappedList[2].date)
+        Assertions.assertEquals(LocalDate.parse("2012-01-02"), mappedList[3].date)
+    }
+
+    @Test
+    fun `Item-on-title mapper should map material types`() {
+        Assertions.assertTrue(mappedList.all {
+            it.materialType == "Avis"
+        })
+    }
+
+    @Test
+    fun `Item-on-title mapper should map title ID`() {
+        Assertions.assertTrue(mappedList.all {
+            it.titleCatalogueId == "3"
+        })
+    }
+
+    @Test
+    fun `Item-on-title mapper should map title name`() {
+        Assertions.assertTrue(mappedList.all {
+            it.titleName == "Bikubeavisen"
+        })
+    }
+
+    @Test
+    fun `Item-on-title mapper should map if digital or not`() {
+        Assertions.assertEquals(false, mappedList[0].digital)
+        Assertions.assertEquals(true, mappedList[1].digital)
+        Assertions.assertEquals(false, mappedList[2].digital)
+        Assertions.assertEquals(true, mappedList[3].digital)
+    }
+}

--- a/src/test/kotlin/no/nb/bikube/core/mapper/TitleMapperTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/mapper/TitleMapperTests.kt
@@ -1,0 +1,85 @@
+package no.nb.bikube.core.mapper
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nb.bikube.core.model.CollectionsDating
+import no.nb.bikube.core.model.CollectionsModel
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.io.File
+import java.time.LocalDate
+
+@SpringBootTest
+@ActiveProfiles("test")
+class TitleMapperTests {
+    private fun mapper(): ObjectMapper {
+        val mapper = jacksonObjectMapper()
+        // Disable unknown properties as we are not using all fields, and will test for what we need
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        return mapper
+    }
+
+    private val singleTitleJson = File("src/test/resources/CollectionsJsonTestFiles/NewspaperTitleSingle.json")
+    private val singleTitle = mapper().readValue<CollectionsModel>(singleTitleJson).adlibJson.recordList.first()
+    private val genericTitle = mapCollectionsObjectToGenericTitle(singleTitle)
+
+    @Test
+    fun `Title mapper should map catalogueId `() {
+        Assertions.assertEquals("3", genericTitle.catalogueId)
+    }
+
+    @Test
+    fun `Title mapper should map start date`() {
+        Assertions.assertEquals(LocalDate.parse("1947-01-01"), genericTitle.startDate)
+    }
+
+    @Test
+    fun `Title mapper should map end date`() {
+        Assertions.assertEquals(LocalDate.parse("1999-01-09"), genericTitle.endDate)
+    }
+
+    @Test
+    fun `Title mapper should map language`() {
+        Assertions.assertEquals("nob", genericTitle.language)
+    }
+
+    @Test
+    fun `Title mapper should map material type`() {
+        Assertions.assertEquals("Avis", genericTitle.materialType)
+    }
+
+    @Test
+    fun `Title mapper should map title`() {
+        Assertions.assertEquals("Bikubeavisen", genericTitle.name)
+    }
+
+    @Test
+    fun `Title mapper should map publication place `() {
+        Assertions.assertEquals("Mo i Rana", genericTitle.publisherPlace)
+    }
+
+    @Test
+    fun `Title mapper should map publisher`() {
+        Assertions.assertEquals("Amedia", genericTitle.publisher)
+    }
+
+    @Test
+    fun `Title mapper should map year dates`() {
+        val testTitle = singleTitle.copy(datingList = listOf(CollectionsDating("1979", "1999")))
+        val testGenericTitle = mapCollectionsObjectToGenericTitle(testTitle)
+        Assertions.assertEquals(LocalDate.parse("1979-01-01"), testGenericTitle.startDate)
+        Assertions.assertEquals(LocalDate.parse("1999-01-01"), testGenericTitle.endDate)
+    }
+
+    @Test
+    fun `Title mapper should map date dates`() {
+        val testTitle = singleTitle.copy(datingList = listOf(CollectionsDating("1979-01-01", "1999-08-09")))
+        val testGenericTitle = mapCollectionsObjectToGenericTitle(testTitle)
+        Assertions.assertEquals(LocalDate.parse("1979-01-01"), testGenericTitle.startDate)
+        Assertions.assertEquals(LocalDate.parse("1999-08-09"), testGenericTitle.endDate)
+    }
+}

--- a/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonListNewspaperItemsTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonListNewspaperItemsTests.kt
@@ -1,0 +1,136 @@
+package no.nb.bikube.core.model
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nb.bikube.core.enum.AxiellDescriptionType
+import no.nb.bikube.core.enum.AxiellFormat
+import no.nb.bikube.core.enum.AxiellRecordType
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.io.File
+
+@SpringBootTest
+@ActiveProfiles("test")
+class CollectionsModelFromJsonListNewspaperItemsTests {
+    private fun mapper(): ObjectMapper {
+        val mapper = jacksonObjectMapper()
+        // Disable unknown properties as we are not using all fields, and will test for what we need
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        return mapper
+    }
+
+    private val itemListJson = File("src/test/resources/CollectionsJsonTestFiles/NewspaperItemList.json")
+    private val items = mapper().readValue<CollectionsModel>(itemListJson).adlibJson.recordList
+
+    @Test
+    fun `Collection object should extract all items`() {
+        Assertions.assertEquals(4, items.size)
+    }
+
+    @Test
+    fun `Collection object should extract priRefs `() {
+        Assertions.assertEquals("5", items.first().priRef)
+        Assertions.assertEquals("6", items[1].priRef)
+        Assertions.assertEquals("19", items[2].priRef)
+        Assertions.assertEquals("21", items[3].priRef)
+    }
+
+    @Test
+    fun `Collection object should extract submediums`() {
+        Assertions.assertTrue(items.all { it.subMediumList!!.first().subMedium == "Avis" })
+    }
+
+    @Test
+    fun `Collection object should extract names`() {
+        Assertions.assertEquals("Bikubeavisen 2012.01.02", items.first().titleList!!.first().title)
+        Assertions.assertEquals("Bikubeavisen 2012.01.02", items[1].titleList!!.first().title)
+        Assertions.assertEquals("Bikubeavisen 2011.01.24", items[2].titleList!!.first().title)
+        Assertions.assertEquals("Bikubeavisen 2012.01.09", items[3].titleList!!.first().title)
+    }
+
+    @Test
+    fun `Collection object should extract record types`() {
+        Assertions.assertTrue(items.all { it.recordTypeList!!.first().first{ langObj -> langObj.lang == "neutral" }.text == "ITEM" })
+    }
+
+    @Test
+    fun `Collection object should extract formats`() {
+        Assertions.assertEquals(AxiellFormat.DIGITAL.value, items.first().formatList!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals(AxiellFormat.PHYSICAL.value, items[1].formatList!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals(AxiellFormat.PHYSICAL.value, items[2].formatList!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals(AxiellFormat.DIGITAL.value, items[3].formatList!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+    }
+
+    @Test
+    fun `Collection object should extract parent manifestations`() {
+        val mani1 = items.first().partOfList!!.first().partOfReference!!
+        Assertions.assertEquals("10", mani1.priRef)
+        Assertions.assertEquals("Bikubeavisen 2012.01.02", mani1.title!!.first().title)
+        Assertions.assertEquals(AxiellRecordType.MANIFESTATION.value, mani1.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals("Avis", mani1.subMedium!!.first().subMedium)
+
+        // Manifestation 1 and 2 should be the same
+        val mani2 = items[1].partOfList!!.first().partOfReference!!
+        Assertions.assertEquals(mani1, mani2)
+
+        val mani3 = items[2].partOfList!!.first().partOfReference!!
+        Assertions.assertEquals("18", mani3.priRef)
+        Assertions.assertEquals("Bikubeavisen 2011.01.24", mani3.title!!.first().title)
+        Assertions.assertEquals(AxiellRecordType.MANIFESTATION.value, mani3.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals("Avis", mani3.subMedium!!.first().subMedium)
+
+        val mani4 = items[3].partOfList!!.first().partOfReference!!
+        Assertions.assertEquals("20", mani4.priRef)
+        Assertions.assertEquals("Bikubeavisen 2012.01.09", mani4.title!!.first().title)
+        Assertions.assertEquals(AxiellRecordType.MANIFESTATION.value, mani4.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals("Avis", mani4.subMedium!!.first().subMedium)
+    }
+
+    @Test
+    fun `Collection object should extract parent year works`() {
+        val yearWork1 = items.first().partOfList!!.first().partOfReference!!.partOfGroup!!.first().partOfReference!!
+        Assertions.assertEquals("4", yearWork1.priRef)
+        Assertions.assertEquals("Bikubeavisen 2012", yearWork1.title!!.first().title)
+        Assertions.assertEquals(AxiellRecordType.WORK.value, yearWork1.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals("Avis", yearWork1.subMedium!!.first().subMedium)
+        Assertions.assertEquals(AxiellDescriptionType.YEAR.value, yearWork1.workTypeList!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+
+        // Year work 1, 2 and 4 should be the same
+        val yearWork2 = items[1].partOfList!!.first().partOfReference!!.partOfGroup!!.first().partOfReference!!
+        Assertions.assertEquals(yearWork1, yearWork2)
+
+        val yearWork3 = items[2].partOfList!!.first().partOfReference!!.partOfGroup!!.first().partOfReference!!
+        Assertions.assertEquals("11", yearWork3.priRef)
+        Assertions.assertEquals("Bikubeavisen 2011", yearWork3.title!!.first().title)
+        Assertions.assertEquals(AxiellRecordType.WORK.value, yearWork3.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals("Avis", yearWork3.subMedium!!.first().subMedium)
+        Assertions.assertEquals(AxiellDescriptionType.YEAR.value, yearWork3.workTypeList!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+
+        val yearWork4 = items[3].partOfList!!.first().partOfReference!!.partOfGroup!!.first().partOfReference!!
+        Assertions.assertEquals(yearWork1, yearWork4)
+    }
+
+    @Test
+    fun `Collection object should extract parent serial works`() {
+        // All items are connected to the same title
+        val title1 = items.first().partOfList!!.first().partOfReference!!.partOfGroup!!.first().partOfReference!!.partOfGroup!!.first().partOfReference!!
+        Assertions.assertEquals("3", title1.priRef)
+        Assertions.assertEquals("Bikubeavisen", title1.title!!.first().title)
+        Assertions.assertEquals(AxiellRecordType.WORK.value, title1.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals("Avis", title1.subMedium!!.first().subMedium)
+        Assertions.assertEquals(AxiellDescriptionType.SERIAL.value, title1.workTypeList!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+
+        val title2 = items[1].partOfList!!.first().partOfReference!!.partOfGroup!!.first().partOfReference!!.partOfGroup!!.first().partOfReference!!
+        Assertions.assertEquals(title1, title2)
+
+        val title3 = items[2].partOfList!!.first().partOfReference!!.partOfGroup!!.first().partOfReference!!.partOfGroup!!.first().partOfReference!!
+        Assertions.assertEquals(title1, title3)
+
+        val title4 = items[3].partOfList!!.first().partOfReference!!.partOfGroup!!.first().partOfReference!!.partOfGroup!!.first().partOfReference!!
+        Assertions.assertEquals(title1, title4)
+    }
+}

--- a/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonListNewspaperTitlesTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonListNewspaperTitlesTests.kt
@@ -1,0 +1,55 @@
+package no.nb.bikube.core.model
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.io.File
+
+@SpringBootTest
+@ActiveProfiles("test")
+class CollectionsModelFromJsonListNewspaperTitlesTests {
+    private fun mapper(): ObjectMapper {
+        val mapper = jacksonObjectMapper()
+        // Disable unknown properties as we are not using all fields, and will test for what we need
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        return mapper
+    }
+
+    private val titleListJson = File("src/test/resources/CollectionsJsonTestFiles/NewspaperTitleList.json")
+    private val titles = mapper().readValue<CollectionsModel>(titleListJson).adlibJson.recordList
+
+    @Test
+    fun `Title object should extract all items`() {
+        Assertions.assertEquals(3, titles.size)
+    }
+
+    @Test
+    fun `Title object should extract priRefs`() {
+        Assertions.assertEquals("3", titles.first().priRef)
+        Assertions.assertEquals("7", titles[1].priRef)
+        Assertions.assertEquals("9", titles[2].priRef)
+    }
+
+    @Test
+    fun `Title object should extract submediums`() {
+        Assertions.assertTrue(titles.all { it.subMediumList!!.first().subMedium == "Avis" })
+    }
+
+    @Test
+    fun `Title object should extract title`() {
+        Assertions.assertEquals("Bikubeavisen", titles.first().titleList!!.first().title)
+        Assertions.assertEquals("Bikubeposten", titles[1].titleList!!.first().title)
+        Assertions.assertEquals("The Bikube", titles[2].titleList!!.first().title)
+    }
+
+    @Test
+    fun `Title object should extract record types`() {
+        Assertions.assertTrue(titles.all { it.recordTypeList!!.first().first{ langObj -> langObj.lang == "neutral" }.text == "WORK" })
+    }
+
+}

--- a/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonSingleNewspaperItemTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonSingleNewspaperItemTests.kt
@@ -30,27 +30,55 @@ class CollectionsModelFromJsonSingleNewspaperItemTests {
     fun `Item object should extract priRef`() { Assertions.assertEquals("5", singleItem.priRef) }
 
     @Test
-    fun `Item object should extract format`() { Assertions.assertEquals(AxiellFormat.DIGITAL.value, singleItem.formatList!!.first().first { langObj -> langObj.lang == "neutral" }.text) }
+    fun `Item object should extract format`() {
+        Assertions.assertEquals(
+            AxiellFormat.DIGITAL.value,
+            singleItem.formatList!!.first().first { langObj -> langObj.lang == "neutral" }.text
+        )
+    }
 
     @Test
-    fun `Item object should extract medium`() { Assertions.assertEquals("Tekst", singleItem.mediumList!!.first().medium) }
+    fun `Item object should extract medium`() {
+        Assertions.assertEquals(
+            "Tekst",
+            singleItem.mediumList!!.first().medium
+        )
+    }
 
     @Test
-    fun `Item object should extract submedium`() { Assertions.assertEquals("Avis", singleItem.subMediumList!!.first().subMedium) }
+    fun `Item object should extract submedium`() {
+        Assertions.assertEquals(
+            "Avis",
+            singleItem.subMediumList!!.first().subMedium
+        )
+    }
 
     @Test
-    fun `Item object should extract title`() { Assertions.assertEquals("Bikubeavisen 2012.01.02", singleItem.titleList!!.first().title) }
+    fun `Item object should extract title`() {
+        Assertions.assertEquals(
+            "Bikubeavisen 2012.01.02",
+            singleItem.titleList!!.first().title
+        )
+    }
 
     @Test
-    fun `Item object should extract recordtype`() { Assertions.assertEquals(AxiellRecordType.ITEM.value, singleItem.recordTypeList!!.first().first { langObj -> langObj.lang == "neutral" }.text) }
+    fun `Item object should extract recordtype`() {
+        Assertions.assertEquals(
+            AxiellRecordType.ITEM.value,
+            singleItem.recordTypeList!!.first().first { langObj -> langObj.lang == "neutral" }.text
+        )
+    }
 
     @Test
     fun `Item object should extract parent manifestation`() {
         val manifestation = singleItem.partOfList!!.first().partOfReference!!
         Assertions.assertEquals("10", manifestation.priRef)
         Assertions.assertEquals("Bikubeavisen 2012.01.02", manifestation.title!!.first().title)
-        Assertions.assertEquals(AxiellRecordType.MANIFESTATION.value, manifestation.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
         Assertions.assertEquals("Avis", manifestation.subMedium!!.first().subMedium)
+        Assertions.assertEquals(
+            AxiellRecordType.MANIFESTATION.value,
+            manifestation.recordType!!.first().first { langObj -> langObj.lang == "neutral"}.text
+        )
     }
 
     @Test

--- a/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonSingleNewspaperItemTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonSingleNewspaperItemTests.kt
@@ -1,0 +1,76 @@
+package no.nb.bikube.core.model
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nb.bikube.core.enum.AxiellDescriptionType
+import no.nb.bikube.core.enum.AxiellFormat
+import no.nb.bikube.core.enum.AxiellRecordType
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.io.File
+
+@SpringBootTest
+@ActiveProfiles("test")
+class CollectionsModelFromJsonSingleNewspaperItemTests {
+    private fun mapper(): ObjectMapper {
+        val mapper = jacksonObjectMapper()
+        // Disable unknown properties as we are not using all fields, and will test for what we need
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        return mapper
+    }
+
+    private val singleItemJson = File("src/test/resources/CollectionsJsonTestFiles/NewspaperItemSingle.json")
+    private val singleItem = mapper().readValue<CollectionsModel>(singleItemJson).adlibJson.recordList.first()
+
+    @Test
+    fun `Item object should extract priRef`() { Assertions.assertEquals("5", singleItem.priRef) }
+
+    @Test
+    fun `Item object should extract format`() { Assertions.assertEquals(AxiellFormat.DIGITAL.value, singleItem.formatList!!.first().first { langObj -> langObj.lang == "neutral" }.text) }
+
+    @Test
+    fun `Item object should extract medium`() { Assertions.assertEquals("Tekst", singleItem.mediumList!!.first().medium) }
+
+    @Test
+    fun `Item object should extract submedium`() { Assertions.assertEquals("Avis", singleItem.subMediumList!!.first().subMedium) }
+
+    @Test
+    fun `Item object should extract title`() { Assertions.assertEquals("Bikubeavisen 2012.01.02", singleItem.titleList!!.first().title) }
+
+    @Test
+    fun `Item object should extract recordtype`() { Assertions.assertEquals(AxiellRecordType.ITEM.value, singleItem.recordTypeList!!.first().first { langObj -> langObj.lang == "neutral" }.text) }
+
+    @Test
+    fun `Item object should extract parent manifestation`() {
+        val manifestation = singleItem.partOfList!!.first().partOfReference!!
+        Assertions.assertEquals("10", manifestation.priRef)
+        Assertions.assertEquals("Bikubeavisen 2012.01.02", manifestation.title!!.first().title)
+        Assertions.assertEquals(AxiellRecordType.MANIFESTATION.value, manifestation.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals("Avis", manifestation.subMedium!!.first().subMedium)
+    }
+
+    @Test
+    fun `Item object should extract parent year work`() {
+        val yearWork = singleItem.partOfList!!.first().partOfReference!!.partOfGroup!!.first().partOfReference!!
+        Assertions.assertEquals("4", yearWork.priRef)
+        Assertions.assertEquals("Bikubeavisen 2012", yearWork.title!!.first().title)
+        Assertions.assertEquals(AxiellRecordType.WORK.value, yearWork.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals("Avis", yearWork.subMedium!!.first().subMedium)
+        Assertions.assertEquals(AxiellDescriptionType.YEAR.value, yearWork.workTypeList!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+    }
+
+    @Test
+    fun `Item object should extract parent title`() {
+        val title = singleItem.partOfList!!.first().partOfReference!!.partOfGroup!!.first().partOfReference!!.partOfGroup!!.first().partOfReference!!
+        Assertions.assertEquals("3", title.priRef)
+        Assertions.assertEquals("Bikubeavisen", title.title!!.first().title)
+        Assertions.assertEquals(AxiellRecordType.WORK.value, title.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals("Avis", title.subMedium!!.first().subMedium)
+        Assertions.assertEquals(AxiellDescriptionType.SERIAL.value, title.workTypeList!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+    }
+
+}

--- a/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonSingleNewspaperTitleTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonSingleNewspaperTitleTests.kt
@@ -51,7 +51,12 @@ class CollectionsModelFromJsonSingleNewspaperTitleTests {
     fun `Title object should extract publisher`() { Assertions.assertEquals("Amedia", singleTitle.publisherList!!.first()) }
 
     @Test
-    fun `Title object should extract work type`() { Assertions.assertEquals(AxiellDescriptionType.SERIAL.value, singleTitle.workTypeList!!.first().first { langObj -> langObj.lang == "neutral" }.text) }
+    fun `Title object should extract work type`() {
+        Assertions.assertEquals(
+            AxiellDescriptionType.SERIAL.value,
+            singleTitle.workTypeList!!.first().first { langObj -> langObj.lang == "neutral" }.text
+        )
+    }
 
     @Test
     fun `Title object should extract child year works`() {
@@ -107,7 +112,11 @@ class CollectionsModelFromJsonSingleNewspaperTitleTests {
     @Test
     fun `Title object should extract child items`() {
         val items = mutableListOf<CollectionsPartsObject>()
-        singleTitle.partsList!!.forEach { yearWorks -> yearWorks.partsReference!!.partsList?.forEach { manifestations -> manifestations.partsReference!!.partsList?.forEach { items.add(it) } } }
+        singleTitle.partsList!!.forEach { yearWorks ->
+            yearWorks.partsReference!!.partsList?.forEach { manifestations ->
+                manifestations.partsReference!!.partsList?.forEach { items.add(it) }
+            }
+        }
         Assertions.assertEquals(4, items.size)
 
         val item1 = items.first().partsReference!!

--- a/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonSingleNewspaperTitleTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonSingleNewspaperTitleTests.kt
@@ -1,0 +1,138 @@
+package no.nb.bikube.core.model
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nb.bikube.core.enum.AxiellDescriptionType
+import no.nb.bikube.core.enum.AxiellFormat
+import no.nb.bikube.core.enum.AxiellRecordType
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.io.File
+
+@SpringBootTest
+@ActiveProfiles("test")
+class CollectionsModelFromJsonSingleNewspaperTitleTests {
+    private fun mapper(): ObjectMapper {
+        val mapper = jacksonObjectMapper()
+        // Disable unknown properties as we are not using all fields, and will test for what we need
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        return mapper
+    }
+
+    private val singleTitleJson = File("src/test/resources/CollectionsJsonTestFiles/NewspaperTitleSingle.json")
+    private val singleTitle = mapper().readValue<CollectionsModel>(singleTitleJson).adlibJson.recordList.first()
+
+    @Test
+    fun `Title object should extract priRef`() { Assertions.assertEquals("3", singleTitle.priRef) }
+
+    @Test
+    fun `Title object should extract start date`() { Assertions.assertEquals("1947-01-01", singleTitle.datingList!!.first().dateFrom) }
+
+    @Test
+    fun `Title object should extract end date`() { Assertions.assertEquals("1999-01-09", singleTitle.datingList!!.first().dateTo) }
+
+    @Test
+    fun `Title object should extract language`() { Assertions.assertEquals("nob", singleTitle.languageList!!.first().language) }
+
+    @Test
+    fun `Title object should extract submedium`() { Assertions.assertEquals("Avis", singleTitle.subMediumList!!.first().subMedium) }
+
+    @Test
+    fun `Title object should extract title`() { Assertions.assertEquals("Bikubeavisen", singleTitle.titleList!!.first().title) }
+
+    @Test
+    fun `Title object should extract publication place `() { Assertions.assertEquals("Mo i Rana", singleTitle.placeOfPublicationList!!.first()) }
+
+    @Test
+    fun `Title object should extract publisher`() { Assertions.assertEquals("Amedia", singleTitle.publisherList!!.first()) }
+
+    @Test
+    fun `Title object should extract work type`() { Assertions.assertEquals(AxiellDescriptionType.SERIAL.value, singleTitle.workTypeList!!.first().first { langObj -> langObj.lang == "neutral" }.text) }
+
+    @Test
+    fun `Title object should extract child year works`() {
+        val yearWorks = singleTitle.partsList!!
+        Assertions.assertEquals(2, yearWorks.size)
+
+        val firstYear = yearWorks.first().partsReference!!
+        Assertions.assertEquals("11", firstYear.priRef)
+        Assertions.assertEquals("Bikubeavisen 2011", firstYear.titleList!!.first().title)
+        Assertions.assertEquals(AxiellRecordType.WORK.value, firstYear.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals(AxiellDescriptionType.YEAR.value, firstYear.workTypeList!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals(1, firstYear.partsList!!.size)
+
+        val secondYear = yearWorks[1].partsReference!!
+        Assertions.assertEquals("4", secondYear.priRef)
+        Assertions.assertEquals("Bikubeavisen 2012", secondYear.titleList!!.first().title)
+        Assertions.assertEquals(AxiellRecordType.WORK.value, secondYear.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals(AxiellDescriptionType.YEAR.value, secondYear.workTypeList!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals(3, secondYear.partsList!!.size)
+    }
+
+    @Test
+    fun `Title object should extract child manifestations`() {
+        val manifestations = mutableListOf<CollectionsPartsObject>()
+        singleTitle.partsList!!.forEach { yearWorks -> yearWorks.partsReference!!.partsList?.forEach { manifestations.add(it) } }
+        Assertions.assertEquals(4, manifestations.size)
+
+        val manifest1 = manifestations.first().partsReference!!
+        Assertions.assertEquals("18", manifest1.priRef)
+        Assertions.assertEquals("Bikubeavisen 2011.01.24", manifest1.titleList!!.first().title)
+        Assertions.assertEquals(AxiellRecordType.MANIFESTATION.value, manifest1.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals(1, manifest1.partsList!!.size)
+
+        val manifest2 = manifestations[1].partsReference!!
+        Assertions.assertEquals("22", manifest2.priRef)
+        Assertions.assertEquals("Bikubeavisen 2012.01.10", manifest2.titleList!!.first().title)
+        Assertions.assertEquals(AxiellRecordType.MANIFESTATION.value, manifest2.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals(null, manifest2.partsList)
+
+        val manifest3 = manifestations[2].partsReference!!
+        Assertions.assertEquals("20", manifest3.priRef)
+        Assertions.assertEquals("Bikubeavisen 2012.01.09", manifest3.titleList!!.first().title)
+        Assertions.assertEquals(AxiellRecordType.MANIFESTATION.value, manifest3.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals(1, manifest3.partsList!!.size)
+
+        val manifest4 = manifestations[3].partsReference!!
+        Assertions.assertEquals("10", manifest4.priRef)
+        Assertions.assertEquals("Bikubeavisen 2012.01.02", manifest4.titleList!!.first().title)
+        Assertions.assertEquals(AxiellRecordType.MANIFESTATION.value, manifest4.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals(2, manifest4.partsList!!.size)
+    }
+
+    @Test
+    fun `Title object should extract child items`() {
+        val items = mutableListOf<CollectionsPartsObject>()
+        singleTitle.partsList!!.forEach { yearWorks -> yearWorks.partsReference!!.partsList?.forEach { manifestations -> manifestations.partsReference!!.partsList?.forEach { items.add(it) } } }
+        Assertions.assertEquals(4, items.size)
+
+        val item1 = items.first().partsReference!!
+        Assertions.assertEquals("19", item1.priRef)
+        Assertions.assertEquals("Bikubeavisen 2011.01.24", item1.titleList!!.first().title)
+        Assertions.assertEquals(AxiellRecordType.ITEM.value, item1.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals(AxiellFormat.PHYSICAL.value, item1.formatList!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+
+        val item2 = items[1].partsReference!!
+        Assertions.assertEquals("21", item2.priRef)
+        Assertions.assertEquals("Bikubeavisen 2012.01.09", item2.titleList!!.first().title)
+        Assertions.assertEquals(AxiellRecordType.ITEM.value, item2.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals(AxiellFormat.DIGITAL.value, item2.formatList!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+
+        val item3 = items[2].partsReference!!
+        Assertions.assertEquals("6", item3.priRef)
+        Assertions.assertEquals("Bikubeavisen 2012.01.02", item3.titleList!!.first().title)
+        Assertions.assertEquals(AxiellRecordType.ITEM.value, item3.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals(AxiellFormat.PHYSICAL.value, item3.formatList!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+
+        val item4 = items[3].partsReference!!
+        Assertions.assertEquals("5", item4.priRef)
+        Assertions.assertEquals("Bikubeavisen 2012.01.02", item4.titleList!!.first().title)
+        Assertions.assertEquals(AxiellRecordType.ITEM.value, item4.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+        Assertions.assertEquals(AxiellFormat.DIGITAL.value, item4.formatList!!.first().first { langObj -> langObj.lang == "neutral" }.text)
+    }
+
+}

--- a/src/test/kotlin/no/nb/bikube/newspaper/NewspaperMockData.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/NewspaperMockData.kt
@@ -1,7 +1,6 @@
 package no.nb.bikube.newspaper
 
-import no.nb.bikube.core.model.Item
-import no.nb.bikube.core.model.Title
+import no.nb.bikube.core.model.*
 
 class NewspaperMockData {
     companion object {
@@ -24,6 +23,26 @@ class NewspaperMockData {
             titleCatalogueId = newspaperTitleMockA.catalogueId,
             titleName = newspaperTitleMockA.name,
             digital = true
+        )
+
+        val collectionsModelMockA = CollectionsModel(
+            adlibJson = CollectionsRecordList(
+                recordList = listOf(CollectionsObject(
+                    priRef = "1",
+                    titleList = null,
+                    recordTypeList = null,
+                    formatList = null,
+                    partOfList = null,
+                    subMediumList = null,
+                    mediumList = null,
+                    datingList = null,
+                    publisherList = null,
+                    languageList = null,
+                    placeOfPublicationList = null,
+                    partsList = null,
+                    workTypeList = null
+                ))
+            )
         )
     }
 }

--- a/src/test/resources/CollectionsJsonTestFiles/NewspaperItemList.json
+++ b/src/test/resources/CollectionsJsonTestFiles/NewspaperItemList.json
@@ -1,0 +1,982 @@
+{
+  "adlibJSON": {
+    "recordList": [
+      {
+        "@priref": 5,
+        "@created": "2023-09-20T08:57:58",
+        "@modification": "2023-09-26T10:55:04",
+        "@selected": false,
+        "format": [
+          [
+            {
+              "@lang": "neutral",
+              "#text": "DIGITAL"
+            },
+            {
+              "@lang": 0,
+              "#text": "Digital item"
+            },
+            {
+              "@lang": 12,
+              "#text": "Digital"
+            }
+          ]
+        ],
+        "Part_of": [
+          {
+            "part_of_reference": {
+              "group:Part_of": [
+                {
+                  "part_of_reference": {
+                    "group:Part_of": [
+                      {
+                        "part_of_reference": {
+                          "group:Submedium": [
+                            {
+                              "submedium": "Avis"
+                            }
+                          ],
+                          "group:Title": [
+                            {
+                              "title": "Bikubeavisen"
+                            }
+                          ],
+                          "object_number": "3",
+                          "priref": "3",
+                          "record_type": [
+                            [
+                              {
+                                "@lang": "neutral",
+                                "#text": "WORK"
+                              },
+                              {
+                                "@lang": 0,
+                                "#text": "Work"
+                              },
+                              {
+                                "@lang": 1,
+                                "#text": "Werk"
+                              },
+                              {
+                                "@lang": 3,
+                                "#text": "Werk"
+                              },
+                              {
+                                "@lang": 9,
+                                "#text": "Verk"
+                              },
+                              {
+                                "@lang": 12,
+                                "#text": "Verk"
+                              }
+                            ]
+                          ],
+                          "work.description_type": [
+                            [
+                              {
+                                "@lang": "neutral",
+                                "#text": "SERIAL"
+                              },
+                              {
+                                "@lang": 0,
+                                "#text": "Serial"
+                              },
+                              {
+                                "@lang": 1,
+                                "#text": "Tijdschrift"
+                              },
+                              {
+                                "@lang": 3,
+                                "#text": "Zeitschrift"
+                              },
+                              {
+                                "@lang": 9,
+                                "#text": "Serie"
+                              },
+                              {
+                                "@lang": 12,
+                                "#text": "Serie"
+                              }
+                            ]
+                          ]
+                        }
+                      }
+                    ],
+                    "group:Submedium": [
+                      {
+                        "submedium": "Avis"
+                      }
+                    ],
+                    "group:Title": [
+                      {
+                        "title": "Bikubeavisen 2012"
+                      }
+                    ],
+                    "object_number": "4",
+                    "priref": "4",
+                    "record_type": [
+                      [
+                        {
+                          "@lang": "neutral",
+                          "#text": "WORK"
+                        },
+                        {
+                          "@lang": 0,
+                          "#text": "Work"
+                        },
+                        {
+                          "@lang": 1,
+                          "#text": "Werk"
+                        },
+                        {
+                          "@lang": 3,
+                          "#text": "Werk"
+                        },
+                        {
+                          "@lang": 9,
+                          "#text": "Verk"
+                        },
+                        {
+                          "@lang": 12,
+                          "#text": "Verk"
+                        }
+                      ]
+                    ],
+                    "work.description_type": [
+                      [
+                        {
+                          "@lang": "neutral",
+                          "#text": "YEAR"
+                        },
+                        {
+                          "@lang": 0,
+                          "#text": "Year"
+                        },
+                        {
+                          "@lang": 12,
+                          "#text": "År"
+                        }
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "group:Submedium": [
+                {
+                  "submedium": "Avis"
+                }
+              ],
+              "group:Title": [
+                {
+                  "title": "Bikubeavisen 2012.01.02"
+                }
+              ],
+              "object_number": "12",
+              "priref": "10",
+              "record_type": [
+                [
+                  {
+                    "@lang": "neutral",
+                    "#text": "MANIFESTATION"
+                  },
+                  {
+                    "@lang": 0,
+                    "#text": "Manifestation"
+                  },
+                  {
+                    "@lang": 1,
+                    "#text": "Manifestatie"
+                  },
+                  {
+                    "@lang": 3,
+                    "#text": "Manifestation"
+                  },
+                  {
+                    "@lang": 9,
+                    "#text": "Manifestation"
+                  },
+                  {
+                    "@lang": 12,
+                    "#text": "Manifestasjon"
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Submedium": [
+          {
+            "submedium": "Avis"
+          }
+        ],
+        "Title": [
+          {
+            "title": "Bikubeavisen 2012.01.02"
+          }
+        ],
+        "object_number": "5",
+        "priref": "5",
+        "record_type": [
+          [
+            {
+              "@lang": "neutral",
+              "#text": "ITEM"
+            },
+            {
+              "@lang": 0,
+              "#text": "Item"
+            },
+            {
+              "@lang": 1,
+              "#text": "Item"
+            },
+            {
+              "@lang": 3,
+              "#text": "Exemplar"
+            },
+            {
+              "@lang": 9,
+              "#text": "Objekt"
+            },
+            {
+              "@lang": 12,
+              "#text": "Objekt/Komponent"
+            }
+          ]
+        ]
+      },
+      {
+        "@priref": 6,
+        "@created": "2023-09-20T09:02:55",
+        "@modification": "2023-09-22T13:07:24",
+        "@selected": false,
+        "format": [
+          [
+            {
+              "@lang": "neutral",
+              "#text": "PHYSICAL"
+            },
+            {
+              "@lang": 0,
+              "#text": "Physical item"
+            },
+            {
+              "@lang": 12,
+              "#text": "Fysisk"
+            }
+          ]
+        ],
+        "Part_of": [
+          {
+            "part_of_reference": {
+              "group:Part_of": [
+                {
+                  "part_of_reference": {
+                    "group:Part_of": [
+                      {
+                        "part_of_reference": {
+                          "group:Submedium": [
+                            {
+                              "submedium": "Avis"
+                            }
+                          ],
+                          "group:Title": [
+                            {
+                              "title": "Bikubeavisen"
+                            }
+                          ],
+                          "object_number": "3",
+                          "priref": "3",
+                          "record_type": [
+                            [
+                              {
+                                "@lang": "neutral",
+                                "#text": "WORK"
+                              },
+                              {
+                                "@lang": 0,
+                                "#text": "Work"
+                              },
+                              {
+                                "@lang": 1,
+                                "#text": "Werk"
+                              },
+                              {
+                                "@lang": 3,
+                                "#text": "Werk"
+                              },
+                              {
+                                "@lang": 9,
+                                "#text": "Verk"
+                              },
+                              {
+                                "@lang": 12,
+                                "#text": "Verk"
+                              }
+                            ]
+                          ],
+                          "work.description_type": [
+                            [
+                              {
+                                "@lang": "neutral",
+                                "#text": "SERIAL"
+                              },
+                              {
+                                "@lang": 0,
+                                "#text": "Serial"
+                              },
+                              {
+                                "@lang": 1,
+                                "#text": "Tijdschrift"
+                              },
+                              {
+                                "@lang": 3,
+                                "#text": "Zeitschrift"
+                              },
+                              {
+                                "@lang": 9,
+                                "#text": "Serie"
+                              },
+                              {
+                                "@lang": 12,
+                                "#text": "Serie"
+                              }
+                            ]
+                          ]
+                        }
+                      }
+                    ],
+                    "group:Submedium": [
+                      {
+                        "submedium": "Avis"
+                      }
+                    ],
+                    "group:Title": [
+                      {
+                        "title": "Bikubeavisen 2012"
+                      }
+                    ],
+                    "object_number": "4",
+                    "priref": "4",
+                    "record_type": [
+                      [
+                        {
+                          "@lang": "neutral",
+                          "#text": "WORK"
+                        },
+                        {
+                          "@lang": 0,
+                          "#text": "Work"
+                        },
+                        {
+                          "@lang": 1,
+                          "#text": "Werk"
+                        },
+                        {
+                          "@lang": 3,
+                          "#text": "Werk"
+                        },
+                        {
+                          "@lang": 9,
+                          "#text": "Verk"
+                        },
+                        {
+                          "@lang": 12,
+                          "#text": "Verk"
+                        }
+                      ]
+                    ],
+                    "work.description_type": [
+                      [
+                        {
+                          "@lang": "neutral",
+                          "#text": "YEAR"
+                        },
+                        {
+                          "@lang": 0,
+                          "#text": "Year"
+                        },
+                        {
+                          "@lang": 12,
+                          "#text": "År"
+                        }
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "group:Submedium": [
+                {
+                  "submedium": "Avis"
+                }
+              ],
+              "group:Title": [
+                {
+                  "title": "Bikubeavisen 2012.01.02"
+                }
+              ],
+              "object_number": "12",
+              "priref": "10",
+              "record_type": [
+                [
+                  {
+                    "@lang": "neutral",
+                    "#text": "MANIFESTATION"
+                  },
+                  {
+                    "@lang": 0,
+                    "#text": "Manifestation"
+                  },
+                  {
+                    "@lang": 1,
+                    "#text": "Manifestatie"
+                  },
+                  {
+                    "@lang": 3,
+                    "#text": "Manifestation"
+                  },
+                  {
+                    "@lang": 9,
+                    "#text": "Manifestation"
+                  },
+                  {
+                    "@lang": 12,
+                    "#text": "Manifestasjon"
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Submedium": [
+          {
+            "submedium": "Avis"
+          }
+        ],
+        "Title": [
+          {
+            "title": "Bikubeavisen 2012.01.02"
+          }
+        ],
+        "object_number": "6",
+        "priref": "6",
+        "record_type": [
+          [
+            {
+              "@lang": "neutral",
+              "#text": "ITEM"
+            },
+            {
+              "@lang": 0,
+              "#text": "Item"
+            },
+            {
+              "@lang": 1,
+              "#text": "Item"
+            },
+            {
+              "@lang": 3,
+              "#text": "Exemplar"
+            },
+            {
+              "@lang": 9,
+              "#text": "Objekt"
+            },
+            {
+              "@lang": 12,
+              "#text": "Objekt/Komponent"
+            }
+          ]
+        ]
+      },
+      {
+        "@priref": 19,
+        "@created": "2023-09-26T09:22:56",
+        "@modification": "2023-09-26T09:24:38",
+        "@selected": false,
+        "format": [
+          [
+            {
+              "@lang": "neutral",
+              "#text": "PHYSICAL"
+            },
+            {
+              "@lang": 0,
+              "#text": "Physical item"
+            },
+            {
+              "@lang": 12,
+              "#text": "Fysisk"
+            }
+          ]
+        ],
+        "Part_of": [
+          {
+            "part_of_reference": {
+              "group:Part_of": [
+                {
+                  "part_of_reference": {
+                    "group:Part_of": [
+                      {
+                        "part_of_reference": {
+                          "group:Submedium": [
+                            {
+                              "submedium": "Avis"
+                            }
+                          ],
+                          "group:Title": [
+                            {
+                              "title": "Bikubeavisen"
+                            }
+                          ],
+                          "object_number": "3",
+                          "priref": "3",
+                          "record_type": [
+                            [
+                              {
+                                "@lang": "neutral",
+                                "#text": "WORK"
+                              },
+                              {
+                                "@lang": 0,
+                                "#text": "Work"
+                              },
+                              {
+                                "@lang": 1,
+                                "#text": "Werk"
+                              },
+                              {
+                                "@lang": 3,
+                                "#text": "Werk"
+                              },
+                              {
+                                "@lang": 9,
+                                "#text": "Verk"
+                              },
+                              {
+                                "@lang": 12,
+                                "#text": "Verk"
+                              }
+                            ]
+                          ],
+                          "work.description_type": [
+                            [
+                              {
+                                "@lang": "neutral",
+                                "#text": "SERIAL"
+                              },
+                              {
+                                "@lang": 0,
+                                "#text": "Serial"
+                              },
+                              {
+                                "@lang": 1,
+                                "#text": "Tijdschrift"
+                              },
+                              {
+                                "@lang": 3,
+                                "#text": "Zeitschrift"
+                              },
+                              {
+                                "@lang": 9,
+                                "#text": "Serie"
+                              },
+                              {
+                                "@lang": 12,
+                                "#text": "Serie"
+                              }
+                            ]
+                          ]
+                        }
+                      }
+                    ],
+                    "group:Submedium": [
+                      {
+                        "submedium": "Avis"
+                      }
+                    ],
+                    "group:Title": [
+                      {
+                        "title": "Bikubeavisen 2011"
+                      }
+                    ],
+                    "object_number": "13",
+                    "priref": "11",
+                    "record_type": [
+                      [
+                        {
+                          "@lang": "neutral",
+                          "#text": "WORK"
+                        },
+                        {
+                          "@lang": 0,
+                          "#text": "Work"
+                        },
+                        {
+                          "@lang": 1,
+                          "#text": "Werk"
+                        },
+                        {
+                          "@lang": 3,
+                          "#text": "Werk"
+                        },
+                        {
+                          "@lang": 9,
+                          "#text": "Verk"
+                        },
+                        {
+                          "@lang": 12,
+                          "#text": "Verk"
+                        }
+                      ]
+                    ],
+                    "work.description_type": [
+                      [
+                        {
+                          "@lang": "neutral",
+                          "#text": "YEAR"
+                        },
+                        {
+                          "@lang": 0,
+                          "#text": "Year"
+                        },
+                        {
+                          "@lang": 12,
+                          "#text": "År"
+                        }
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "group:Submedium": [
+                {
+                  "submedium": "Avis"
+                }
+              ],
+              "group:Title": [
+                {
+                  "title": "Bikubeavisen 2011.01.24"
+                }
+              ],
+              "object_number": "20",
+              "priref": "18",
+              "record_type": [
+                [
+                  {
+                    "@lang": "neutral",
+                    "#text": "MANIFESTATION"
+                  },
+                  {
+                    "@lang": 0,
+                    "#text": "Manifestation"
+                  },
+                  {
+                    "@lang": 1,
+                    "#text": "Manifestatie"
+                  },
+                  {
+                    "@lang": 3,
+                    "#text": "Manifestation"
+                  },
+                  {
+                    "@lang": 9,
+                    "#text": "Manifestation"
+                  },
+                  {
+                    "@lang": 12,
+                    "#text": "Manifestasjon"
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Submedium": [
+          {
+            "submedium": "Avis"
+          }
+        ],
+        "Title": [
+          {
+            "title": "Bikubeavisen 2011.01.24"
+          }
+        ],
+        "object_number": "21",
+        "priref": "19",
+        "record_type": [
+          [
+            {
+              "@lang": "neutral",
+              "#text": "ITEM"
+            },
+            {
+              "@lang": 0,
+              "#text": "Item"
+            },
+            {
+              "@lang": 1,
+              "#text": "Item"
+            },
+            {
+              "@lang": 3,
+              "#text": "Exemplar"
+            },
+            {
+              "@lang": 9,
+              "#text": "Objekt"
+            },
+            {
+              "@lang": 12,
+              "#text": "Objekt/Komponent"
+            }
+          ]
+        ]
+      },
+      {
+        "@priref": 21,
+        "@created": "2023-09-26T09:25:09",
+        "@modification": "2023-09-26T09:25:27",
+        "@selected": false,
+        "format": [
+          [
+            {
+              "@lang": "neutral",
+              "#text": "DIGITAL"
+            },
+            {
+              "@lang": 0,
+              "#text": "Digital item"
+            },
+            {
+              "@lang": 12,
+              "#text": "Digital"
+            }
+          ]
+        ],
+        "Part_of": [
+          {
+            "part_of_reference": {
+              "group:Part_of": [
+                {
+                  "part_of_reference": {
+                    "group:Part_of": [
+                      {
+                        "part_of_reference": {
+                          "group:Submedium": [
+                            {
+                              "submedium": "Avis"
+                            }
+                          ],
+                          "group:Title": [
+                            {
+                              "title": "Bikubeavisen"
+                            }
+                          ],
+                          "object_number": "3",
+                          "priref": "3",
+                          "record_type": [
+                            [
+                              {
+                                "@lang": "neutral",
+                                "#text": "WORK"
+                              },
+                              {
+                                "@lang": 0,
+                                "#text": "Work"
+                              },
+                              {
+                                "@lang": 1,
+                                "#text": "Werk"
+                              },
+                              {
+                                "@lang": 3,
+                                "#text": "Werk"
+                              },
+                              {
+                                "@lang": 9,
+                                "#text": "Verk"
+                              },
+                              {
+                                "@lang": 12,
+                                "#text": "Verk"
+                              }
+                            ]
+                          ],
+                          "work.description_type": [
+                            [
+                              {
+                                "@lang": "neutral",
+                                "#text": "SERIAL"
+                              },
+                              {
+                                "@lang": 0,
+                                "#text": "Serial"
+                              },
+                              {
+                                "@lang": 1,
+                                "#text": "Tijdschrift"
+                              },
+                              {
+                                "@lang": 3,
+                                "#text": "Zeitschrift"
+                              },
+                              {
+                                "@lang": 9,
+                                "#text": "Serie"
+                              },
+                              {
+                                "@lang": 12,
+                                "#text": "Serie"
+                              }
+                            ]
+                          ]
+                        }
+                      }
+                    ],
+                    "group:Submedium": [
+                      {
+                        "submedium": "Avis"
+                      }
+                    ],
+                    "group:Title": [
+                      {
+                        "title": "Bikubeavisen 2012"
+                      }
+                    ],
+                    "object_number": "4",
+                    "priref": "4",
+                    "record_type": [
+                      [
+                        {
+                          "@lang": "neutral",
+                          "#text": "WORK"
+                        },
+                        {
+                          "@lang": 0,
+                          "#text": "Work"
+                        },
+                        {
+                          "@lang": 1,
+                          "#text": "Werk"
+                        },
+                        {
+                          "@lang": 3,
+                          "#text": "Werk"
+                        },
+                        {
+                          "@lang": 9,
+                          "#text": "Verk"
+                        },
+                        {
+                          "@lang": 12,
+                          "#text": "Verk"
+                        }
+                      ]
+                    ],
+                    "work.description_type": [
+                      [
+                        {
+                          "@lang": "neutral",
+                          "#text": "YEAR"
+                        },
+                        {
+                          "@lang": 0,
+                          "#text": "Year"
+                        },
+                        {
+                          "@lang": 12,
+                          "#text": "År"
+                        }
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "group:Submedium": [
+                {
+                  "submedium": "Avis"
+                }
+              ],
+              "group:Title": [
+                {
+                  "title": "Bikubeavisen 2012.01.09"
+                }
+              ],
+              "object_number": "22",
+              "priref": "20",
+              "record_type": [
+                [
+                  {
+                    "@lang": "neutral",
+                    "#text": "MANIFESTATION"
+                  },
+                  {
+                    "@lang": 0,
+                    "#text": "Manifestation"
+                  },
+                  {
+                    "@lang": 1,
+                    "#text": "Manifestatie"
+                  },
+                  {
+                    "@lang": 3,
+                    "#text": "Manifestation"
+                  },
+                  {
+                    "@lang": 9,
+                    "#text": "Manifestation"
+                  },
+                  {
+                    "@lang": 12,
+                    "#text": "Manifestasjon"
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Submedium": [
+          {
+            "submedium": "Avis"
+          }
+        ],
+        "Title": [
+          {
+            "title": "Bikubeavisen 2012.01.09"
+          }
+        ],
+        "object_number": "23",
+        "priref": "21",
+        "record_type": [
+          [
+            {
+              "@lang": "neutral",
+              "#text": "ITEM"
+            },
+            {
+              "@lang": 0,
+              "#text": "Item"
+            },
+            {
+              "@lang": 1,
+              "#text": "Item"
+            },
+            {
+              "@lang": 3,
+              "#text": "Exemplar"
+            },
+            {
+              "@lang": 9,
+              "#text": "Objekt"
+            },
+            {
+              "@lang": 12,
+              "#text": "Objekt/Komponent"
+            }
+          ]
+        ]
+      }
+    ]
+  }
+}

--- a/src/test/resources/CollectionsJsonTestFiles/NewspaperItemSingle.json
+++ b/src/test/resources/CollectionsJsonTestFiles/NewspaperItemSingle.json
@@ -1,0 +1,255 @@
+{
+  "adlibJSON": {
+    "recordList": [
+      {
+        "@priref": 5,
+        "@created": "2023-09-20T08:57:58",
+        "@modification": "2023-09-26T10:55:04",
+        "@selected": false,
+        "format": [
+          [
+            {
+              "@lang": "neutral",
+              "#text": "DIGITAL"
+            },
+            {
+              "@lang": 0,
+              "#text": "Digital item"
+            },
+            {
+              "@lang": 12,
+              "#text": "Digital"
+            }
+          ]
+        ],
+        "Medium": [
+          {
+            "medium": "Tekst"
+          }
+        ],
+        "Part_of": [
+          {
+            "part_of_reference": {
+              "group:Part_of": [
+                {
+                  "part_of_reference": {
+                    "group:Part_of": [
+                      {
+                        "part_of_reference": {
+                          "group:Submedium": [
+                            {
+                              "submedium": "Avis"
+                            }
+                          ],
+                          "group:Title": [
+                            {
+                              "title": "Bikubeavisen"
+                            }
+                          ],
+                          "object_number": "3",
+                          "priref": "3",
+                          "record_type": [
+                            [
+                              {
+                                "@lang": "neutral",
+                                "#text": "WORK"
+                              },
+                              {
+                                "@lang": 0,
+                                "#text": "Work"
+                              },
+                              {
+                                "@lang": 1,
+                                "#text": "Werk"
+                              },
+                              {
+                                "@lang": 3,
+                                "#text": "Werk"
+                              },
+                              {
+                                "@lang": 9,
+                                "#text": "Verk"
+                              },
+                              {
+                                "@lang": 12,
+                                "#text": "Verk"
+                              }
+                            ]
+                          ],
+                          "work.description_type": [
+                            [
+                              {
+                                "@lang": "neutral",
+                                "#text": "SERIAL"
+                              },
+                              {
+                                "@lang": 0,
+                                "#text": "Serial"
+                              },
+                              {
+                                "@lang": 1,
+                                "#text": "Tijdschrift"
+                              },
+                              {
+                                "@lang": 3,
+                                "#text": "Zeitschrift"
+                              },
+                              {
+                                "@lang": 9,
+                                "#text": "Serie"
+                              },
+                              {
+                                "@lang": 12,
+                                "#text": "Serie"
+                              }
+                            ]
+                          ]
+                        }
+                      }
+                    ],
+                    "group:Submedium": [
+                      {
+                        "submedium": "Avis"
+                      }
+                    ],
+                    "group:Title": [
+                      {
+                        "title": "Bikubeavisen 2012"
+                      }
+                    ],
+                    "object_number": "4",
+                    "priref": "4",
+                    "record_type": [
+                      [
+                        {
+                          "@lang": "neutral",
+                          "#text": "WORK"
+                        },
+                        {
+                          "@lang": 0,
+                          "#text": "Work"
+                        },
+                        {
+                          "@lang": 1,
+                          "#text": "Werk"
+                        },
+                        {
+                          "@lang": 3,
+                          "#text": "Werk"
+                        },
+                        {
+                          "@lang": 9,
+                          "#text": "Verk"
+                        },
+                        {
+                          "@lang": 12,
+                          "#text": "Verk"
+                        }
+                      ]
+                    ],
+                    "work.description_type": [
+                      [
+                        {
+                          "@lang": "neutral",
+                          "#text": "YEAR"
+                        },
+                        {
+                          "@lang": 0,
+                          "#text": "Year"
+                        },
+                        {
+                          "@lang": 12,
+                          "#text": "År"
+                        }
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "group:Submedium": [
+                {
+                  "submedium": "Avis"
+                }
+              ],
+              "group:Title": [
+                {
+                  "title": "Bikubeavisen 2012.01.02"
+                }
+              ],
+              "object_number": "12",
+              "priref": "10",
+              "record_type": [
+                [
+                  {
+                    "@lang": "neutral",
+                    "#text": "MANIFESTATION"
+                  },
+                  {
+                    "@lang": 0,
+                    "#text": "Manifestation"
+                  },
+                  {
+                    "@lang": 1,
+                    "#text": "Manifestatie"
+                  },
+                  {
+                    "@lang": 3,
+                    "#text": "Manifestation"
+                  },
+                  {
+                    "@lang": 9,
+                    "#text": "Manifestation"
+                  },
+                  {
+                    "@lang": 12,
+                    "#text": "Manifestasjon"
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Submedium": [
+          {
+            "submedium": "Avis"
+          }
+        ],
+        "Title": [
+          {
+            "title": "Bikubeavisen 2012.01.02"
+          }
+        ],
+        "object_number": "5",
+        "priref": "5",
+        "record_type": [
+          [
+            {
+              "@lang": "neutral",
+              "#text": "ITEM"
+            },
+            {
+              "@lang": 0,
+              "#text": "Item"
+            },
+            {
+              "@lang": 1,
+              "#text": "Item"
+            },
+            {
+              "@lang": 3,
+              "#text": "Exemplar"
+            },
+            {
+              "@lang": 9,
+              "#text": "Objekt"
+            },
+            {
+              "@lang": 12,
+              "#text": "Objekt/Komponent"
+            }
+          ]
+        ]
+      }
+    ]
+  }
+}

--- a/src/test/resources/CollectionsJsonTestFiles/NewspaperTitleList.json
+++ b/src/test/resources/CollectionsJsonTestFiles/NewspaperTitleList.json
@@ -1,0 +1,228 @@
+{
+  "adlibJSON": {
+    "recordList": [
+      {
+        "@priref": 3,
+        "@created": "2023-09-20T08:38:07",
+        "@modification": "2023-09-26T12:10:00",
+        "@selected": false,
+        "Submedium": [
+          {
+            "submedium": "Avis"
+          }
+        ],
+        "Title": [
+          {
+            "title": "Bikubeavisen"
+          }
+        ],
+        "object_number": "3",
+        "priref": "3",
+        "record_type": [
+          [
+            {
+              "@lang": "neutral",
+              "#text": "WORK"
+            },
+            {
+              "@lang": 0,
+              "#text": "Work"
+            },
+            {
+              "@lang": 1,
+              "#text": "Werk"
+            },
+            {
+              "@lang": 3,
+              "#text": "Werk"
+            },
+            {
+              "@lang": 9,
+              "#text": "Verk"
+            },
+            {
+              "@lang": 12,
+              "#text": "Verk"
+            }
+          ]
+        ],
+        "work.description_type": [
+          [
+            {
+              "@lang": "neutral",
+              "#text": "SERIAL"
+            },
+            {
+              "@lang": 0,
+              "#text": "Serial"
+            },
+            {
+              "@lang": 1,
+              "#text": "Tijdschrift"
+            },
+            {
+              "@lang": 3,
+              "#text": "Zeitschrift"
+            },
+            {
+              "@lang": 9,
+              "#text": "Serie"
+            },
+            {
+              "@lang": 12,
+              "#text": "Serie"
+            }
+          ]
+        ]
+      },
+      {
+        "@priref": 7,
+        "@created": "2023-09-20T09:19:26",
+        "@modification": "2023-09-26T12:09:48",
+        "@selected": false,
+        "Submedium": [
+          {
+            "submedium": "Avis"
+          }
+        ],
+        "Title": [
+          {
+            "title": "Bikubeposten"
+          }
+        ],
+        "object_number": "7",
+        "priref": "7",
+        "record_type": [
+          [
+            {
+              "@lang": "neutral",
+              "#text": "WORK"
+            },
+            {
+              "@lang": 0,
+              "#text": "Work"
+            },
+            {
+              "@lang": 1,
+              "#text": "Werk"
+            },
+            {
+              "@lang": 3,
+              "#text": "Werk"
+            },
+            {
+              "@lang": 9,
+              "#text": "Verk"
+            },
+            {
+              "@lang": 12,
+              "#text": "Verk"
+            }
+          ]
+        ],
+        "work.description_type": [
+          [
+            {
+              "@lang": "neutral",
+              "#text": "SERIAL"
+            },
+            {
+              "@lang": 0,
+              "#text": "Serial"
+            },
+            {
+              "@lang": 1,
+              "#text": "Tijdschrift"
+            },
+            {
+              "@lang": 3,
+              "#text": "Zeitschrift"
+            },
+            {
+              "@lang": 9,
+              "#text": "Serie"
+            },
+            {
+              "@lang": 12,
+              "#text": "Serie"
+            }
+          ]
+        ]
+      },
+      {
+        "@priref": 9,
+        "@created": "2023-09-20T10:27:23",
+        "@modification": "2023-09-20T10:33:13",
+        "@selected": false,
+        "Submedium": [
+          {
+            "submedium": "Avis"
+          }
+        ],
+        "Title": [
+          {
+            "title": "The Bikube"
+          }
+        ],
+        "object_number": "9",
+        "priref": "9",
+        "record_type": [
+          [
+            {
+              "@lang": "neutral",
+              "#text": "WORK"
+            },
+            {
+              "@lang": 0,
+              "#text": "Work"
+            },
+            {
+              "@lang": 1,
+              "#text": "Werk"
+            },
+            {
+              "@lang": 3,
+              "#text": "Werk"
+            },
+            {
+              "@lang": 9,
+              "#text": "Verk"
+            },
+            {
+              "@lang": 12,
+              "#text": "Verk"
+            }
+          ]
+        ],
+        "work.description_type": [
+          [
+            {
+              "@lang": "neutral",
+              "#text": "SERIAL"
+            },
+            {
+              "@lang": 0,
+              "#text": "Serial"
+            },
+            {
+              "@lang": 1,
+              "#text": "Tijdschrift"
+            },
+            {
+              "@lang": 3,
+              "#text": "Zeitschrift"
+            },
+            {
+              "@lang": 9,
+              "#text": "Serie"
+            },
+            {
+              "@lang": 12,
+              "#text": "Serie"
+            }
+          ]
+        ]
+      }
+    ]
+  }
+}

--- a/src/test/resources/CollectionsJsonTestFiles/NewspaperTitleSingle.json
+++ b/src/test/resources/CollectionsJsonTestFiles/NewspaperTitleSingle.json
@@ -1,0 +1,600 @@
+{
+  "adlibJSON": {
+    "recordList": [
+      {
+        "@priref": 3,
+        "@created": "2023-09-20T08:38:07",
+        "@modification": "2023-09-26T12:10:00",
+        "@selected": false,
+        "Dating": [
+          {
+            "dating.date.start": "1947-01-01",
+            "dating.date.end": "1999-01-09"
+          }
+        ],
+        "Language": [
+          {
+            "language": "nob"
+          }
+        ],
+        "Medium": [
+          {
+            "medium": "Tekst"
+          }
+        ],
+        "Parts": [
+          {
+            "parts_reference": {
+              "group:Parts": [
+                {
+                  "parts_reference": {
+                    "group:Parts": [
+                      {
+                        "parts_reference": {
+                          "format": [
+                            [
+                              {
+                                "@lang": "neutral",
+                                "#text": "PHYSICAL"
+                              },
+                              {
+                                "@lang": 0,
+                                "#text": "Physical item"
+                              },
+                              {
+                                "@lang": 12,
+                                "#text": "Fysisk"
+                              }
+                            ]
+                          ],
+                          "group:Title": [
+                            {
+                              "title": "Bikubeavisen 2011.01.24"
+                            }
+                          ],
+                          "object_number": "21",
+                          "priref": "19",
+                          "record_type": [
+                            [
+                              {
+                                "@lang": "neutral",
+                                "#text": "ITEM"
+                              },
+                              {
+                                "@lang": 0,
+                                "#text": "Item"
+                              },
+                              {
+                                "@lang": 1,
+                                "#text": "Item"
+                              },
+                              {
+                                "@lang": 3,
+                                "#text": "Exemplar"
+                              },
+                              {
+                                "@lang": 9,
+                                "#text": "Objekt"
+                              },
+                              {
+                                "@lang": 12,
+                                "#text": "Objekt/Komponent"
+                              }
+                            ]
+                          ]
+                        }
+                      }
+                    ],
+                    "group:Title": [
+                      {
+                        "title": "Bikubeavisen 2011.01.24"
+                      }
+                    ],
+                    "object_number": "20",
+                    "priref": "18",
+                    "record_type": [
+                      [
+                        {
+                          "@lang": "neutral",
+                          "#text": "MANIFESTATION"
+                        },
+                        {
+                          "@lang": 0,
+                          "#text": "Manifestation"
+                        },
+                        {
+                          "@lang": 1,
+                          "#text": "Manifestatie"
+                        },
+                        {
+                          "@lang": 3,
+                          "#text": "Manifestation"
+                        },
+                        {
+                          "@lang": 9,
+                          "#text": "Manifestation"
+                        },
+                        {
+                          "@lang": 12,
+                          "#text": "Manifestasjon"
+                        }
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "group:Title": [
+                {
+                  "title": "Bikubeavisen 2011"
+                }
+              ],
+              "object_number": "13",
+              "priref": "11",
+              "record_type": [
+                [
+                  {
+                    "@lang": "neutral",
+                    "#text": "WORK"
+                  },
+                  {
+                    "@lang": 0,
+                    "#text": "Work"
+                  },
+                  {
+                    "@lang": 1,
+                    "#text": "Werk"
+                  },
+                  {
+                    "@lang": 3,
+                    "#text": "Werk"
+                  },
+                  {
+                    "@lang": 9,
+                    "#text": "Verk"
+                  },
+                  {
+                    "@lang": 12,
+                    "#text": "Verk"
+                  }
+                ]
+              ],
+              "work.description_type": [
+                [
+                  {
+                    "@lang": "neutral",
+                    "#text": "YEAR"
+                  },
+                  {
+                    "@lang": 0,
+                    "#text": "Year"
+                  },
+                  {
+                    "@lang": 12,
+                    "#text": "År"
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "parts_reference": {
+              "group:Parts": [
+                {
+                  "parts_reference": {
+                    "group:Title": [
+                      {
+                        "title": "Bikubeavisen 2012.01.10"
+                      }
+                    ],
+                    "object_number": "24",
+                    "priref": "22",
+                    "record_type": [
+                      [
+                        {
+                          "@lang": "neutral",
+                          "#text": "MANIFESTATION"
+                        },
+                        {
+                          "@lang": 0,
+                          "#text": "Manifestation"
+                        },
+                        {
+                          "@lang": 1,
+                          "#text": "Manifestatie"
+                        },
+                        {
+                          "@lang": 3,
+                          "#text": "Manifestation"
+                        },
+                        {
+                          "@lang": 9,
+                          "#text": "Manifestation"
+                        },
+                        {
+                          "@lang": 12,
+                          "#text": "Manifestasjon"
+                        }
+                      ]
+                    ]
+                  }
+                },
+                {
+                  "parts_reference": {
+                    "group:Parts": [
+                      {
+                        "parts_reference": {
+                          "format": [
+                            [
+                              {
+                                "@lang": "neutral",
+                                "#text": "DIGITAL"
+                              },
+                              {
+                                "@lang": 0,
+                                "#text": "Digital item"
+                              },
+                              {
+                                "@lang": 12,
+                                "#text": "Digital"
+                              }
+                            ]
+                          ],
+                          "group:Title": [
+                            {
+                              "title": "Bikubeavisen 2012.01.09"
+                            }
+                          ],
+                          "object_number": "23",
+                          "priref": "21",
+                          "record_type": [
+                            [
+                              {
+                                "@lang": "neutral",
+                                "#text": "ITEM"
+                              },
+                              {
+                                "@lang": 0,
+                                "#text": "Item"
+                              },
+                              {
+                                "@lang": 1,
+                                "#text": "Item"
+                              },
+                              {
+                                "@lang": 3,
+                                "#text": "Exemplar"
+                              },
+                              {
+                                "@lang": 9,
+                                "#text": "Objekt"
+                              },
+                              {
+                                "@lang": 12,
+                                "#text": "Objekt/Komponent"
+                              }
+                            ]
+                          ]
+                        }
+                      }
+                    ],
+                    "group:Title": [
+                      {
+                        "title": "Bikubeavisen 2012.01.09"
+                      }
+                    ],
+                    "object_number": "22",
+                    "priref": "20",
+                    "record_type": [
+                      [
+                        {
+                          "@lang": "neutral",
+                          "#text": "MANIFESTATION"
+                        },
+                        {
+                          "@lang": 0,
+                          "#text": "Manifestation"
+                        },
+                        {
+                          "@lang": 1,
+                          "#text": "Manifestatie"
+                        },
+                        {
+                          "@lang": 3,
+                          "#text": "Manifestation"
+                        },
+                        {
+                          "@lang": 9,
+                          "#text": "Manifestation"
+                        },
+                        {
+                          "@lang": 12,
+                          "#text": "Manifestasjon"
+                        }
+                      ]
+                    ]
+                  }
+                },
+                {
+                  "parts_reference": {
+                    "group:Parts": [
+                      {
+                        "parts_reference": {
+                          "format": [
+                            [
+                              {
+                                "@lang": "neutral",
+                                "#text": "PHYSICAL"
+                              },
+                              {
+                                "@lang": 0,
+                                "#text": "Physical item"
+                              },
+                              {
+                                "@lang": 12,
+                                "#text": "Fysisk"
+                              }
+                            ]
+                          ],
+                          "group:Title": [
+                            {
+                              "title": "Bikubeavisen 2012.01.02"
+                            }
+                          ],
+                          "object_number": "6",
+                          "priref": "6",
+                          "record_type": [
+                            [
+                              {
+                                "@lang": "neutral",
+                                "#text": "ITEM"
+                              },
+                              {
+                                "@lang": 0,
+                                "#text": "Item"
+                              },
+                              {
+                                "@lang": 1,
+                                "#text": "Item"
+                              },
+                              {
+                                "@lang": 3,
+                                "#text": "Exemplar"
+                              },
+                              {
+                                "@lang": 9,
+                                "#text": "Objekt"
+                              },
+                              {
+                                "@lang": 12,
+                                "#text": "Objekt/Komponent"
+                              }
+                            ]
+                          ]
+                        }
+                      },
+                      {
+                        "parts_reference": {
+                          "format": [
+                            [
+                              {
+                                "@lang": "neutral",
+                                "#text": "DIGITAL"
+                              },
+                              {
+                                "@lang": 0,
+                                "#text": "Digital item"
+                              },
+                              {
+                                "@lang": 12,
+                                "#text": "Digital"
+                              }
+                            ]
+                          ],
+                          "group:Title": [
+                            {
+                              "title": "Bikubeavisen 2012.01.02"
+                            }
+                          ],
+                          "object_number": "5",
+                          "priref": "5",
+                          "record_type": [
+                            [
+                              {
+                                "@lang": "neutral",
+                                "#text": "ITEM"
+                              },
+                              {
+                                "@lang": 0,
+                                "#text": "Item"
+                              },
+                              {
+                                "@lang": 1,
+                                "#text": "Item"
+                              },
+                              {
+                                "@lang": 3,
+                                "#text": "Exemplar"
+                              },
+                              {
+                                "@lang": 9,
+                                "#text": "Objekt"
+                              },
+                              {
+                                "@lang": 12,
+                                "#text": "Objekt/Komponent"
+                              }
+                            ]
+                          ]
+                        }
+                      }
+                    ],
+                    "group:Title": [
+                      {
+                        "title": "Bikubeavisen 2012.01.02"
+                      }
+                    ],
+                    "object_number": "12",
+                    "priref": "10",
+                    "record_type": [
+                      [
+                        {
+                          "@lang": "neutral",
+                          "#text": "MANIFESTATION"
+                        },
+                        {
+                          "@lang": 0,
+                          "#text": "Manifestation"
+                        },
+                        {
+                          "@lang": 1,
+                          "#text": "Manifestatie"
+                        },
+                        {
+                          "@lang": 3,
+                          "#text": "Manifestation"
+                        },
+                        {
+                          "@lang": 9,
+                          "#text": "Manifestation"
+                        },
+                        {
+                          "@lang": 12,
+                          "#text": "Manifestasjon"
+                        }
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "group:Title": [
+                {
+                  "title": "Bikubeavisen 2012"
+                }
+              ],
+              "object_number": "4",
+              "priref": "4",
+              "record_type": [
+                [
+                  {
+                    "@lang": "neutral",
+                    "#text": "WORK"
+                  },
+                  {
+                    "@lang": 0,
+                    "#text": "Work"
+                  },
+                  {
+                    "@lang": 1,
+                    "#text": "Werk"
+                  },
+                  {
+                    "@lang": 3,
+                    "#text": "Werk"
+                  },
+                  {
+                    "@lang": 9,
+                    "#text": "Verk"
+                  },
+                  {
+                    "@lang": 12,
+                    "#text": "Verk"
+                  }
+                ]
+              ],
+              "work.description_type": [
+                [
+                  {
+                    "@lang": "neutral",
+                    "#text": "YEAR"
+                  },
+                  {
+                    "@lang": 0,
+                    "#text": "Year"
+                  },
+                  {
+                    "@lang": 12,
+                    "#text": "År"
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Submedium": [
+          {
+            "submedium": "Avis"
+          }
+        ],
+        "Title": [
+          {
+            "title": "Bikubeavisen"
+          }
+        ],
+        "object_number": "3",
+        "place_of_publication": [
+          "Mo i Rana"
+        ],
+        "priref": "3",
+        "publisher": [
+          "Amedia"
+        ],
+        "record_type": [
+          [
+            {
+              "@lang": "neutral",
+              "#text": "WORK"
+            },
+            {
+              "@lang": 0,
+              "#text": "Work"
+            },
+            {
+              "@lang": 1,
+              "#text": "Werk"
+            },
+            {
+              "@lang": 3,
+              "#text": "Werk"
+            },
+            {
+              "@lang": 9,
+              "#text": "Verk"
+            },
+            {
+              "@lang": 12,
+              "#text": "Verk"
+            }
+          ]
+        ],
+        "work.description_type": [
+          [
+            {
+              "@lang": "neutral",
+              "#text": "SERIAL"
+            },
+            {
+              "@lang": 0,
+              "#text": "Serial"
+            },
+            {
+              "@lang": 1,
+              "#text": "Tijdschrift"
+            },
+            {
+              "@lang": 3,
+              "#text": "Zeitschrift"
+            },
+            {
+              "@lang": 9,
+              "#text": "Serie"
+            },
+            {
+              "@lang": 12,
+              "#text": "Serie"
+            }
+          ]
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Copied test examples from Collections 
Created tests for mapping functions (items, items-on-title and titles)
Created tests for mapping from json to CollectionsModel
Removed unused "object_number"
Added materialtype to items-on-title

Internal ref: TT-1117