### PR TITLE
feat: create newspaper title

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<kotlin.version>1.8.22</kotlin.version>
+		<serialization.version>1.6.0</serialization.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -68,7 +69,15 @@
 			<version>4.0.2</version>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.jetbrains.kotlinx</groupId>
+			<artifactId>kotlinx-serialization-json</artifactId>
+			<version>${serialization.version}</version>
+		</dependency>
 	</dependencies>
+
+
 
 	<build>
 		<finalName>${project.artifactId}</finalName>
@@ -82,18 +91,34 @@
 			<plugin>
 				<groupId>org.jetbrains.kotlin</groupId>
 				<artifactId>kotlin-maven-plugin</artifactId>
+				<version>${kotlin.version}</version>
+				<executions>
+					<execution>
+						<id>compile</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+					</execution>
+				</executions>
 				<configuration>
 					<args>
 						<arg>-Xjsr305=strict</arg>
 					</args>
 					<compilerPlugins>
 						<plugin>spring</plugin>
+						<plugin>kotlinx-serialization</plugin>
 					</compilerPlugins>
 				</configuration>
 				<dependencies>
 					<dependency>
 						<groupId>org.jetbrains.kotlin</groupId>
 						<artifactId>kotlin-maven-allopen</artifactId>
+						<version>${kotlin.version}</version>
+					</dependency>
+					<dependency>
+						<groupId>org.jetbrains.kotlin</groupId>
+						<artifactId>kotlin-maven-serialization</artifactId>
 						<version>${kotlin.version}</version>
 					</dependency>
 				</dependencies>

--- a/src/main/kotlin/no/nb/bikube/core/model/Title.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/Title.kt
@@ -10,5 +10,5 @@ data class Title (
     val publisherPlace: String?,
     val language: String?,
     val materialType: String?,
-    val catalogueId: String
+    val catalogueId: String?
 )

--- a/src/main/kotlin/no/nb/bikube/core/model/TitleDto.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/TitleDto.kt
@@ -2,8 +2,6 @@ package no.nb.bikube.core.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonTransformingSerializer
-import kotlinx.serialization.json.jsonObject
 
 @Serializable
 class TitleDto(

--- a/src/main/kotlin/no/nb/bikube/core/model/TitleDto.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/TitleDto.kt
@@ -1,0 +1,14 @@
+package no.nb.bikube.core.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonTransformingSerializer
+import kotlinx.serialization.json.jsonObject
+
+@Serializable
+class TitleDto(
+    val title: String,
+    @SerialName("record_type") val recordType: String?,
+    @SerialName("work.description_type") val descriptionType: String?,
+    @SerialName("submedium") val subMedium: String? = null
+)

--- a/src/main/kotlin/no/nb/bikube/newspaper/config/WebClientConfig.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/config/WebClientConfig.kt
@@ -1,0 +1,14 @@
+package no.nb.bikube.newspaper.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.client.WebClient
+
+@Configuration
+class WebClientConfig(private val axiellConfig: AxiellConfig) {
+
+    @Bean
+    fun webClient(): WebClient {
+        return WebClient.builder().baseUrl(axiellConfig.url).build()
+    }
+}

--- a/src/main/kotlin/no/nb/bikube/newspaper/controller/TitleController.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/controller/TitleController.kt
@@ -9,9 +9,7 @@ import no.nb.bikube.core.model.Title
 import no.nb.bikube.newspaper.service.AxiellService
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import reactor.core.publisher.Flux
 
 @RestController
@@ -29,5 +27,12 @@ class TitleController (
     @Throws(AxiellCollectionsException::class)
     fun getTitles(): ResponseEntity<Flux<Title>> {
         return ResponseEntity.ok(axiellService.getTitles())
+    }
+
+    @PostMapping("/")
+    fun createTitle(
+        @RequestBody title: Title
+    ): ResponseEntity<Flux<Title>> {
+        return ResponseEntity.ok(axiellService.createTitle(title))
     }
 }

--- a/src/main/kotlin/no/nb/bikube/newspaper/controller/TitleController.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/controller/TitleController.kt
@@ -29,10 +29,19 @@ class TitleController (
         return ResponseEntity.ok(axiellService.getTitles())
     }
 
-    @PostMapping("/")
+    @PostMapping("/", produces = [MediaType.APPLICATION_JSON_VALUE])
+    @Operation(summary = "Create a newspaper title")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "OK"),
+        ApiResponse(responseCode = "400", description = "Bad request"),
+        ApiResponse(responseCode = "500", description = "Server error")
+    ])
     fun createTitle(
         @RequestBody title: Title
     ): ResponseEntity<Flux<Title>> {
+        if (title.name.isNullOrEmpty()) {
+            return ResponseEntity.badRequest().build()
+        }
         return ResponseEntity.ok(axiellService.createTitle(title))
     }
 }

--- a/src/main/kotlin/no/nb/bikube/newspaper/service/AxiellService.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/service/AxiellService.kt
@@ -10,24 +10,21 @@ import no.nb.bikube.core.mapper.mapCollectionsObjectToGenericTitle
 import no.nb.bikube.core.mapper.mapCollectionsPartsObjectToGenericItem
 import no.nb.bikube.core.model.*
 import no.nb.bikube.core.util.logger
-import no.nb.bikube.newspaper.config.AxiellConfig
+import no.nb.bikube.newspaper.config.WebClientConfig
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
-import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 @Service
 class AxiellService  (
-    axiellConfig: AxiellConfig
+    private val webClient: WebClientConfig
 ) {
-
-    private val webClient = WebClient.builder().baseUrl(axiellConfig.url).build()
 
     @Throws(AxiellCollectionsException::class)
     fun getTitles(): Flux<Title> {
-        return webClient
+        return webClient.webClient()
             .get()
             .uri {
                 it
@@ -62,7 +59,7 @@ class AxiellService  (
             descriptionType = AxiellDescriptionType.SERIAL.value,
             subMedium = title.materialType
         ))
-        return webClient
+        return webClient.webClient()
             .post()
             .uri {
                 it
@@ -84,7 +81,7 @@ class AxiellService  (
     }
 
     fun getAllItems(): Flux<Item> {
-        return webClient
+        return webClient.webClient()
             .get()
             .uri {
                 it
@@ -108,7 +105,7 @@ class AxiellService  (
 
     @Throws(AxiellCollectionsException::class)
     fun getSingleCollectionsModel(catalogId: String): Mono<CollectionsModel> {
-        return webClient
+        return webClient.webClient()
             .get()
             .uri {
                 it

--- a/src/test/kotlin/no/nb/bikube/newspaper/controller/TitleControllerTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/controller/TitleControllerTest.kt
@@ -31,4 +31,15 @@ class TitleControllerTest {
             }
             .verifyComplete()
     }
+
+    @Test
+    fun `create title should return 200 OK with the created title`() {
+        every { axiellService.createTitle(newspaperTitleMockA) } returns just(newspaperTitleMockA.copy())
+        titleController.createTitle(newspaperTitleMockA).body!!.test()
+            .expectSubscription()
+            .assertNext {
+                Assertions.assertEquals(newspaperTitleMockA, it)
+            }
+            .verifyComplete()
+    }
 }

--- a/src/test/kotlin/no/nb/bikube/newspaper/controller/TitleControllerTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/controller/TitleControllerTest.kt
@@ -42,4 +42,14 @@ class TitleControllerTest {
             }
             .verifyComplete()
     }
+
+    @Test
+    fun `create title should return 400 bad request if request body object title is null or empty`() {
+        Assertions.assertEquals(
+            400, titleController.createTitle(newspaperTitleMockA.copy(name = null)).statusCode.value()
+        )
+        Assertions.assertEquals(
+            400, titleController.createTitle(newspaperTitleMockA.copy(name = "")).statusCode.value()
+        )
+    }
 }


### PR DESCRIPTION
Adds endpoint for creating newspaper title using a Title object, using the name and optionally the materialType.
Uses the official kotlin serialization plugin to map back to Axiell API key names

Internal ref: TT-1096