### PR TITLE
feat: add more fields to title creation object (TT-1123)

### DIFF
--- a/src/main/kotlin/no/nb/bikube/core/model/TitleDto.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/TitleDto.kt
@@ -6,7 +6,28 @@ import kotlinx.serialization.Serializable
 @Serializable
 class TitleDto(
     val title: String,
-    @SerialName("record_type") val recordType: String?,
-    @SerialName("work.description_type") val descriptionType: String?,
-    @SerialName("submedium") val subMedium: String? = null
+
+    @SerialName("record_type")
+    val recordType: String?,
+
+    @SerialName("work.description_type")
+    val descriptionType: String?,
+
+    @SerialName("submedium")
+    val subMedium: String? = null,
+
+    @SerialName("dating.date.start")
+    val dateStart: String? = null,
+
+    @SerialName("dating.date.end")
+    val dateEnd: String? = null,
+
+    @SerialName("publisher")
+    val publisher: String? = null,
+
+    @SerialName("place_of_publication")
+    val placeOfPublication: String? = null,
+
+    @SerialName("language")
+    val language: String? = null
 )

--- a/src/main/kotlin/no/nb/bikube/newspaper/service/AxiellService.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/service/AxiellService.kt
@@ -12,7 +12,6 @@ import no.nb.bikube.core.model.*
 import no.nb.bikube.newspaper.repository.AxiellRepository
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Flux
-import reactor.core.publisher.Mono
 
 @Service
 class AxiellService  (

--- a/src/main/kotlin/no/nb/bikube/newspaper/service/AxiellService.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/service/AxiellService.kt
@@ -12,6 +12,7 @@ import no.nb.bikube.core.model.*
 import no.nb.bikube.newspaper.repository.AxiellRepository
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 @Service
 class AxiellService  (
@@ -29,6 +30,11 @@ class AxiellService  (
     fun createTitle(title: Title): Flux<Title> {
         val encodedBody = Json.encodeToString(TitleDto(
             title = title.name!!,
+            dateStart = title.startDate.toString(),
+            dateEnd = title.endDate.toString(),
+            publisher = title.publisher,
+            placeOfPublication = title.publisherPlace,
+            language = title.language,
             recordType = AxiellRecordType.WORK.value,
             descriptionType = AxiellDescriptionType.SERIAL.value,
             subMedium = title.materialType

--- a/src/test/kotlin/no/nb/bikube/newspaper/service/AxiellServiceTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/service/AxiellServiceTest.kt
@@ -48,18 +48,14 @@ class AxiellServiceTest {
     fun `createTitle should return Title object with default values from Title with only name and materialType`() {
         every { axiellRepository.createTitle(any()) } returns Mono.just(collectionsModelMockTitleE)
 
-        val body = Title(
-            newspaperTitleMockB.name,
-            null,
-            null,
-            null,
-            null,
-            null,
-            newspaperTitleMockB.materialType,
-            null
-        )
+        val body = newspaperTitleMockB.copy()
         val encodedValue = Json.encodeToString(TitleDto(
             title = newspaperTitleMockB.name!!,
+            dateStart = newspaperTitleMockB.startDate.toString(),
+            dateEnd = newspaperTitleMockB.endDate.toString(),
+            publisher = newspaperTitleMockB.publisher,
+            placeOfPublication = newspaperTitleMockB.publisherPlace,
+            language = newspaperTitleMockB.language,
             recordType = AxiellRecordType.WORK.value,
             descriptionType = AxiellDescriptionType.SERIAL.value,
             subMedium = newspaperTitleMockB.materialType


### PR DESCRIPTION
Adds more fields to Title object used for creating new Title

Fields publisher, publicationPlace and language must exist in database, but we must wait for implementation of fetch/create for these fields before adding those checks/tests to createTitle endpoint