### PR TITLE
feat: Get single items and titles on catalog ID(priref) (TT-1111)

### DIFF
--- a/src/main/kotlin/no/nb/bikube/core/controller/CoreController.kt
+++ b/src/main/kotlin/no/nb/bikube/core/controller/CoreController.kt
@@ -1,0 +1,63 @@
+package no.nb.bikube.core.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import no.nb.bikube.core.enum.CatalogueName
+import no.nb.bikube.core.enum.MaterialType
+import no.nb.bikube.core.enum.materialTypeToCatalogueName
+import no.nb.bikube.core.exception.AxiellCollectionsException
+import no.nb.bikube.core.exception.AxiellTitleNotFound
+import no.nb.bikube.core.exception.NotSupportedException
+import no.nb.bikube.core.model.Item
+import no.nb.bikube.core.model.Title
+import no.nb.bikube.newspaper.service.AxiellService
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import reactor.core.publisher.Mono
+
+@RestController
+@Tag(name = "Catalogue objects", description = "Endpoints related to catalog data for all text material")
+@RequestMapping("")
+class CoreController (
+    private val axiellService: AxiellService
+){
+    @GetMapping("/item", produces = [MediaType.APPLICATION_JSON_VALUE])
+    @Operation(summary = "Get single item from catalogue")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "OK"),
+        ApiResponse(responseCode = "500", description = "Server error")
+    ])
+    @Throws(AxiellCollectionsException::class, AxiellTitleNotFound::class, NotSupportedException::class)
+    fun getSingleItem(
+        @RequestParam catalogueId: String,
+        @RequestParam materialType: MaterialType,
+    ): ResponseEntity<Mono<Item>> {
+        return when(materialTypeToCatalogueName(materialType)) {
+            CatalogueName.COLLECTIONS -> ResponseEntity.ok(axiellService.getSingleItem(catalogueId))
+            else -> throw NotSupportedException("Material type $materialType is not supported.")
+        }
+    }
+
+    @GetMapping("/title", produces = [MediaType.APPLICATION_JSON_VALUE])
+    @Operation(summary = "Get single title from catalogue")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "OK"),
+        ApiResponse(responseCode = "500", description = "Server error")
+    ])
+    @Throws(AxiellCollectionsException::class, AxiellTitleNotFound::class, NotSupportedException::class)
+    fun getSingleTitle(
+        @RequestParam catalogueId: String,
+        @RequestParam materialType: MaterialType,
+    ): ResponseEntity<Mono<Title>> {
+        return when(materialTypeToCatalogueName(materialType)) {
+            CatalogueName.COLLECTIONS -> ResponseEntity.ok(axiellService.getSingleTitle(catalogueId))
+            else -> throw NotSupportedException("Material type $materialType is not supported.")
+        }
+    }
+}

--- a/src/main/kotlin/no/nb/bikube/core/enum/CatalogueName.kt
+++ b/src/main/kotlin/no/nb/bikube/core/enum/CatalogueName.kt
@@ -1,0 +1,19 @@
+package no.nb.bikube.core.enum
+
+import no.nb.bikube.core.exception.NotSupportedException
+
+enum class CatalogueName(val value: String) {
+    COLLECTIONS("COLLECTIONS"),
+    HANSKE("HANSKE"),
+    ALMA("ALMA")
+}
+
+@Throws(NotSupportedException::class)
+fun materialTypeToCatalogueName(materialType: MaterialType): CatalogueName {
+    return when (materialType) {
+        MaterialType.NEWSPAPER -> CatalogueName.COLLECTIONS
+        MaterialType.MANUSCRIPT -> CatalogueName.HANSKE
+        MaterialType.PERIODICAL -> CatalogueName.ALMA
+        MaterialType.MONOGRAPH -> CatalogueName.ALMA
+    }
+}

--- a/src/main/kotlin/no/nb/bikube/core/enum/MaterialType.kt
+++ b/src/main/kotlin/no/nb/bikube/core/enum/MaterialType.kt
@@ -1,0 +1,8 @@
+package no.nb.bikube.core.enum
+
+enum class MaterialType (val value: String) {
+    NEWSPAPER("Newspaper"),
+    MANUSCRIPT("Manuscript"),
+    PERIODICAL("Periodical"),
+    MONOGRAPH("Monograph")
+}

--- a/src/main/kotlin/no/nb/bikube/core/exception/GlobalControllerExceptionHandler.kt
+++ b/src/main/kotlin/no/nb/bikube/core/exception/GlobalControllerExceptionHandler.kt
@@ -5,26 +5,49 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
+import java.net.URI
+import java.time.Instant
 
 @ControllerAdvice
 class GlobalControllerExceptionHandler {
     @ExceptionHandler(AxiellCollectionsException::class)
     fun handleAxiellCollectionsException(exception: AxiellCollectionsException): ProblemDetail {
         logger().error("AxiellCollectionsException occurred: ${exception.message}")
-        return ProblemDetail
-            .forStatusAndDetail(
-                HttpStatus.INTERNAL_SERVER_ERROR,
-                exception.message ?: "Error occurred when trying to contact Collection."
-            )
+
+        val problemDetail = ProblemDetail.forStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+        problemDetail.detail = exception.message ?: "Error occurred when trying to contact Collections."
+        problemDetail.addDefaultProperties()
+
+        return problemDetail
     }
 
     @ExceptionHandler(AxiellTitleNotFound::class)
     fun handleAxiellTitleNotFoundException(exception: AxiellTitleNotFound): ProblemDetail {
         logger().error("AxiellTitleNotFound occurred: ${exception.message}")
-        return ProblemDetail
-            .forStatusAndDetail(
-                HttpStatus.NOT_FOUND,
-                "Collections title not found: ${exception.message}"
-            )
+
+        val problemDetail = ProblemDetail.forStatus(HttpStatus.NOT_FOUND)
+        problemDetail.detail = "Collections title not found: ${exception.message}"
+        problemDetail.addDefaultProperties()
+
+        return problemDetail
     }
+
+    @ExceptionHandler(NotSupportedException::class)
+    fun handleNotSupportedException(exception: NotSupportedException): ProblemDetail {
+        logger().warn("NotSupportedException occurred: ${exception.message}")
+
+        val problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST)
+        problemDetail.detail = exception.message ?: "What you are trying to do is not supported."
+        problemDetail.addDefaultProperties()
+
+        return problemDetail
+    }
+}
+
+fun ProblemDetail.addDefaultProperties() {
+    this.type = URI(
+        "https://produksjon.nb.no/bikube/error/" +
+        "${HttpStatus.resolve(this.status)?.name?.lowercase()?.replace("_", "-")}"
+    )
+    this.setProperty("timestamp", Instant.now())
 }

--- a/src/main/kotlin/no/nb/bikube/core/exception/NotSupportedException.kt
+++ b/src/main/kotlin/no/nb/bikube/core/exception/NotSupportedException.kt
@@ -1,0 +1,3 @@
+package no.nb.bikube.core.exception
+
+class NotSupportedException (message: String): Exception(message)

--- a/src/main/kotlin/no/nb/bikube/newspaper/controller/ItemController.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/controller/ItemController.kt
@@ -29,6 +29,7 @@ class ItemController (
         ApiResponse(responseCode = "500", description = "Server error")
     ])
     @Throws(AxiellCollectionsException::class)
+    @Deprecated("Will be removed in a future version as getting all items will have too much data.")
     fun getAllItems(
         @RequestParam(required = false) titleCatalogueId: String?,
     ): Mono<ResponseEntity<List<Item>>> {

--- a/src/main/kotlin/no/nb/bikube/newspaper/controller/TitleController.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/controller/TitleController.kt
@@ -25,6 +25,7 @@ class TitleController (
         ApiResponse(responseCode = "500", description = "Server error")
     ])
     @Throws(AxiellCollectionsException::class)
+    @Deprecated("Will be removed in a future version as getting all titles will have too much data.")
     fun getTitles(): ResponseEntity<Flux<Title>> {
         return ResponseEntity.ok(axiellService.getTitles())
     }

--- a/src/test/kotlin/no/nb/bikube/core/CollectionsModelMockData.kt
+++ b/src/test/kotlin/no/nb/bikube/core/CollectionsModelMockData.kt
@@ -134,7 +134,7 @@ class CollectionsModelMockData {
                         partOfList = null,
                         subMediumList = listOf(SubMedium(subMedium = "Avis")),
                         mediumList = listOf(Medium(medium = "Tekst")),
-                        datingList = listOf(CollectionsDating(dateFrom = "2020", dateTo = null)),
+                        datingList = listOf(CollectionsDating(dateFrom = "2020-01-01", dateTo = null)),
                         publisherList = listOf("NB"),
                         languageList = listOf(CollectionsLanguage(language = "nob")),
                         placeOfPublicationList = listOf("Mo I Rana"),
@@ -237,6 +237,104 @@ class CollectionsModelMockData {
         val collectionsModelEmptyRecordListMock = CollectionsModel(
             adlibJson = CollectionsRecordList(
                 recordList = null
+            )
+        )
+
+        val collectionsPartOfObjectMockSerialWorkA = CollectionsPartOfObject(
+            partOfReference = CollectionsPartOfReference(
+                priRef = "22",
+                partOfGroup = null,
+                title = listOf(CollectionsTitle(title = "Bikubeavisen")),
+                recordType = collectionsRecordTypeListWorkMock,
+                subMedium = listOf(SubMedium(subMedium = "Avis")),
+                workTypeList = collectionsWorkTypeListSerialMock
+            )
+        )
+
+        private val collectionsPartOfObjectMockYearWorkA = CollectionsPartOfObject(
+            partOfReference = CollectionsPartOfReference(
+                priRef = "21",
+                partOfGroup = listOf(collectionsPartOfObjectMockSerialWorkA),
+                title = listOf(CollectionsTitle(title = "Bikubeavisen 1999")),
+                recordType = collectionsRecordTypeListWorkMock,
+                subMedium = null,
+                workTypeList = collectionsWorkTypeListYearMock
+            )
+        )
+
+        private val collectionsPartOfObjectMockManifestA = CollectionsPartOfObject(
+            partOfReference = CollectionsPartOfReference(
+                priRef = "20",
+                partOfGroup = listOf(collectionsPartOfObjectMockYearWorkA),
+                title = listOf(CollectionsTitle(title = "Bikubeavisen 1999.12.24")),
+                recordType = collectionsRecordTypeListManifestMock,
+                subMedium = null,
+                workTypeList = null
+            )
+        )
+
+        val collectionsModelMockItemA = CollectionsModel(
+            adlibJson = CollectionsRecordList(
+                recordList = listOf(
+                    CollectionsObject(
+                        priRef = "19",
+                        titleList = listOf(CollectionsTitle(title = "Bikubeavisen 1999.12.24")),
+                        recordTypeList = collectionsRecordTypeListItemMock,
+                        formatList = collectionsFormatListDigitalMock,
+                        partOfList = listOf(collectionsPartOfObjectMockManifestA),
+                        subMediumList = null,
+                        mediumList = null,
+                        datingList = null,
+                        publisherList = listOf("NB"),
+                        languageList = listOf(CollectionsLanguage(language = "nob")),
+                        placeOfPublicationList = listOf("Mo I Rana"),
+                        partsList = null,
+                        workTypeList = null
+                    )
+                )
+            )
+        )
+
+        val collectionsModelMockManifestationA = CollectionsModel(
+            adlibJson = CollectionsRecordList(
+                recordList = listOf(
+                    CollectionsObject(
+                        priRef = "24",
+                        titleList = listOf(CollectionsTitle(title = "Bikubeavisen 1999.12.24")),
+                        recordTypeList = collectionsRecordTypeListManifestMock,
+                        formatList = null,
+                        partOfList = listOf(collectionsPartOfObjectMockYearWorkA),
+                        subMediumList = null,
+                        mediumList = null,
+                        datingList = null,
+                        publisherList = null,
+                        languageList = null,
+                        placeOfPublicationList = null,
+                        partsList = listOf(collectionsPartsObjectMockItemA),
+                        workTypeList = null
+                    )
+                )
+            )
+        )
+        val collectionsModelMockYearWorkA = CollectionsModel(
+            adlibJson = CollectionsRecordList(
+                recordList = listOf(
+                    CollectionsObject(
+                        priRef = "25",
+                        titleList = listOf(CollectionsTitle(title = "Bikubeavisen 1999")),
+                        recordTypeList = collectionsRecordTypeListWorkMock,
+                        formatList = null,
+                        partOfList = listOf(collectionsPartOfObjectMockSerialWorkA),
+                        subMediumList = null,
+                        mediumList = null,
+                        datingList = null,
+                        publisherList = null,
+                        languageList = null,
+                        placeOfPublicationList = null,
+                        partsList = listOf(collectionsPartsObjectMockManifestationA),
+                        workTypeList = collectionsWorkTypeListYearMock
+                    )
+                )
             )
         )
     }

--- a/src/test/kotlin/no/nb/bikube/core/controller/CoreControllerTest.kt
+++ b/src/test/kotlin/no/nb/bikube/core/controller/CoreControllerTest.kt
@@ -1,0 +1,83 @@
+package no.nb.bikube.core.controller
+
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import no.nb.bikube.core.enum.MaterialType
+import no.nb.bikube.core.exception.NotSupportedException
+import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperItemMockA
+import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperTitleMockA
+import no.nb.bikube.newspaper.service.AxiellService
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import reactor.core.publisher.Mono
+import reactor.kotlin.test.test
+
+@SpringBootTest
+@ActiveProfiles("test")
+class CoreControllerTest {
+    @Autowired
+    private lateinit var coreController: CoreController
+
+    @MockkBean
+    private lateinit var axiellService: AxiellService
+
+    @Test
+    fun `get single item for newspaper should return item in body`() {
+        every { axiellService.getSingleItem(any()) } returns Mono.just(newspaperItemMockA.copy())
+
+        coreController.getSingleItem("1", MaterialType.NEWSPAPER).body!!
+            .test()
+            .expectSubscription()
+            .assertNext {
+                Assertions.assertEquals(newspaperItemMockA, it)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `get single item should throw error when trying to get manuscripts`() {
+        assertThrows<NotSupportedException> { coreController.getSingleItem("1", MaterialType.MANUSCRIPT) }
+    }
+
+    @Test
+    fun `get single item should throw error when trying to get periodicals`() {
+        assertThrows<NotSupportedException> { coreController.getSingleItem("1", MaterialType.PERIODICAL) }
+    }
+
+    @Test
+    fun `get single item should throw error when trying to get monographs`() {
+        assertThrows<NotSupportedException> { coreController.getSingleItem("1", MaterialType.MONOGRAPH) }
+    }
+
+    @Test
+    fun `get single title for newspaper should return title in body`() {
+        every { axiellService.getSingleTitle(any()) } returns Mono.just(newspaperTitleMockA.copy())
+
+        coreController.getSingleTitle("1", MaterialType.NEWSPAPER).body!!
+            .test()
+            .expectSubscription()
+            .assertNext {
+                Assertions.assertEquals(newspaperTitleMockA, it)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `get single title should throw error when trying to get manuscripts`() {
+        assertThrows<NotSupportedException> { coreController.getSingleTitle("1", MaterialType.MANUSCRIPT) }
+    }
+
+    @Test
+    fun `get single title should throw error when trying to get periodicals`() {
+        assertThrows<NotSupportedException> { coreController.getSingleTitle("1", MaterialType.PERIODICAL) }
+    }
+
+    @Test
+    fun `get single title should throw error when trying to get monographs`() {
+        assertThrows<NotSupportedException> { coreController.getSingleTitle("1", MaterialType.MONOGRAPH) }
+    }
+}


### PR DESCRIPTION
Added endpoints for getting items and titles on ID.
Deprecated get all as list will be up to 4m long (!) when data is migrated.