### PR TITLE
feat: search and create publisher, publisherPlace and language when creating title (TT-1129)

### DIFF
--- a/src/main/kotlin/no/nb/bikube/core/controller/CoreController.kt
+++ b/src/main/kotlin/no/nb/bikube/core/controller/CoreController.kt
@@ -64,7 +64,6 @@ class CoreController (
         }
     }
 
-
     @GetMapping("/search", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Search catalogue titles")
     @ApiResponses(value = [

--- a/src/main/kotlin/no/nb/bikube/core/controller/CoreController.kt
+++ b/src/main/kotlin/no/nb/bikube/core/controller/CoreController.kt
@@ -4,17 +4,23 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
-import no.nb.bikube.core.enum.*
+import no.nb.bikube.core.enum.CatalogueName
+import no.nb.bikube.core.enum.MaterialType
+import no.nb.bikube.core.enum.materialTypeToCatalogueName
 import no.nb.bikube.core.exception.AxiellCollectionsException
 import no.nb.bikube.core.exception.AxiellTitleNotFound
 import no.nb.bikube.core.exception.BadRequestBodyException
 import no.nb.bikube.core.exception.NotSupportedException
-import no.nb.bikube.core.model.*
+import no.nb.bikube.core.model.CatalogueRecord
+import no.nb.bikube.core.model.Item
+import no.nb.bikube.core.model.Title
 import no.nb.bikube.newspaper.service.AxiellService
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
@@ -60,12 +66,7 @@ class CoreController (
 
 
     @GetMapping("/search", produces = [MediaType.APPLICATION_JSON_VALUE])
-    @Operation(
-        summary = "Search catalogue",
-        description =
-            "Case insensitive search on various types (titles, publishers, items etc.) and various material types. " +
-            "Supports wildcard operator * for partial matches."
-    )
+    @Operation(summary = "Search catalogue titles")
     @ApiResponses(value = [
         ApiResponse(responseCode = "200", description = "OK"),
         ApiResponse(responseCode = "400", description = "Bad request"),
@@ -73,89 +74,12 @@ class CoreController (
     ])
     fun search(
         @RequestParam searchTerm: String,
-        @RequestParam searchType: SearchType,
         @RequestParam materialType: MaterialType
     ): ResponseEntity<Flux<CatalogueRecord>> {
         if (searchTerm.isEmpty()) throw BadRequestBodyException("Search term cannot be empty.")
-
-        return when (searchType) {
-            SearchType.TITLE -> {
-                when(materialTypeToCatalogueName(materialType)) {
-                    CatalogueName.COLLECTIONS -> ResponseEntity.ok(axiellService.searchTitleByName(searchTerm))
-                    else -> throw NotSupportedException("Material type $materialType is not supported.")
-                }
-            }
-            SearchType.PUBLISHER -> {
-                when(materialTypeToCatalogueName(materialType)) {
-                    CatalogueName.COLLECTIONS -> ResponseEntity.ok(axiellService.searchPublisherByName(searchTerm))
-                    else -> throw NotSupportedException("Material type $materialType is not supported.")
-                }
-            }
-            SearchType.LANGUAGE -> {
-                when(materialTypeToCatalogueName(materialType)) {
-                    CatalogueName.COLLECTIONS -> ResponseEntity.ok(axiellService.searchLanguageByName(searchTerm))
-                    else -> throw NotSupportedException("Material type $materialType is not supported.")
-                }
-            }
-            SearchType.LOCATION -> {
-                when(materialTypeToCatalogueName(materialType)) {
-                    CatalogueName.COLLECTIONS -> ResponseEntity.ok(axiellService.searchPublisherPlaceByName(searchTerm))
-                    else -> throw NotSupportedException("Material type $materialType is not supported.")
-                }
-            }
-            else -> throw NotSupportedException("Search type $searchType is not supported.")
-        }
-    }
-
-    @PostMapping("/publisher", produces = [MediaType.APPLICATION_JSON_VALUE])
-    @Operation(summary = "Create new publisher")
-    @ApiResponses(value = [
-        ApiResponse(responseCode = "200", description = "OK"),
-        ApiResponse(responseCode = "400", description = "Bad request"),
-        ApiResponse(responseCode = "500", description = "Server error")
-    ])
-    fun createPublisher(
-        @RequestBody publisher: String
-    ): Mono<ResponseEntity<Publisher>> {
-        return if (publisher.isEmpty()) {
-            throw BadRequestBodyException("Publisher cannot be empty.")
-        } else axiellService.createPublisher(publisher).map { created ->
-            ResponseEntity.ok(created)
-        }
-    }
-
-    @PostMapping("/publisher-place", produces = [MediaType.APPLICATION_JSON_VALUE])
-    @Operation(summary = "Create new publisher place (location)")
-    @ApiResponses(value = [
-        ApiResponse(responseCode = "200", description = "OK"),
-        ApiResponse(responseCode = "400", description = "Bad request"),
-        ApiResponse(responseCode = "500", description = "Server error")
-    ])
-    fun createPublisherPlace(
-        @RequestBody location: String
-    ): Mono<ResponseEntity<PublisherPlace>> {
-        return if (location.isEmpty()) {
-            throw BadRequestBodyException("Publisher place (location) cannot be empty.")
-        } else axiellService.createPublisherPlace(location).map { created ->
-            ResponseEntity.ok(created)
-        }
-    }
-
-    @PostMapping("/language", produces = [MediaType.APPLICATION_JSON_VALUE])
-    @Operation(summary = "Create new ISO-639-2 language code")
-    @ApiResponses(value = [
-        ApiResponse(responseCode = "200", description = "OK"),
-        ApiResponse(responseCode = "400", description = "Bad request"),
-        ApiResponse(responseCode = "500", description = "Server error")
-    ])
-    fun createLanguage(
-        @RequestBody language: String
-    ): Mono<ResponseEntity<Language>> {
-        if (!Regex("^[a-z]{3}$").matches(language)) {
-            throw BadRequestBodyException("Language code must be a valid ISO-639-2 language code.")
-        }
-        return axiellService.createLanguage(language).map { created ->
-            ResponseEntity.ok(created)
+        return when(materialTypeToCatalogueName(materialType)) {
+            CatalogueName.COLLECTIONS -> ResponseEntity.ok(axiellService.searchTitleByName(searchTerm))
+            else -> throw NotSupportedException("Material type $materialType is not supported.")
         }
     }
 }

--- a/src/main/kotlin/no/nb/bikube/core/controller/CoreController.kt
+++ b/src/main/kotlin/no/nb/bikube/core/controller/CoreController.kt
@@ -117,7 +117,9 @@ class CoreController (
     fun createPublisher(
         @RequestBody publisher: String
     ): Mono<ResponseEntity<Publisher>> {
-        return axiellService.createPublisher(publisher).map { created ->
+        return if (publisher.isEmpty()) {
+            throw BadRequestBodyException("Publisher cannot be empty.")
+        } else axiellService.createPublisher(publisher).map { created ->
             ResponseEntity.ok(created)
         }
     }
@@ -132,7 +134,9 @@ class CoreController (
     fun createPublisherPlace(
         @RequestBody location: String
     ): Mono<ResponseEntity<PublisherPlace>> {
-        return axiellService.createPublisherPlace(location).map { created ->
+        return if (location.isEmpty()) {
+            throw BadRequestBodyException("Publisher place (location) cannot be empty.")
+        } else axiellService.createPublisherPlace(location).map { created ->
             ResponseEntity.ok(created)
         }
     }
@@ -146,7 +150,7 @@ class CoreController (
     ])
     fun createLanguage(
         @RequestBody language: String
-    ): Mono<ResponseEntity<PublisherPlace>> {
+    ): Mono<ResponseEntity<Language>> {
         if (!Regex("^[a-z]{3}$").matches(language)) {
             throw BadRequestBodyException("Language code must be a valid ISO-639-2 language code.")
         }

--- a/src/main/kotlin/no/nb/bikube/core/controller/CoreController.kt
+++ b/src/main/kotlin/no/nb/bikube/core/controller/CoreController.kt
@@ -11,6 +11,7 @@ import no.nb.bikube.core.exception.BadRequestBodyException
 import no.nb.bikube.core.exception.NotSupportedException
 import no.nb.bikube.core.model.*
 import no.nb.bikube.newspaper.service.AxiellService
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -98,7 +99,7 @@ class CoreController (
             }
             SearchType.LOCATION -> {
                 when(materialTypeToCatalogueName(materialType)) {
-                    CatalogueName.COLLECTIONS -> ResponseEntity.ok(axiellService.searchPublisherPlace(searchTerm))
+                    CatalogueName.COLLECTIONS -> ResponseEntity.ok(axiellService.searchPublisherPlaceByName(searchTerm))
                     else -> throw NotSupportedException("Material type $materialType is not supported.")
                 }
             }
@@ -115,8 +116,10 @@ class CoreController (
     ])
     fun createPublisher(
         @RequestBody publisher: String
-    ): ResponseEntity<Mono<Publisher>> {
-        return ResponseEntity.ok(axiellService.createPublisher(publisher))
+    ): Mono<ResponseEntity<Publisher>> {
+        return axiellService.createPublisher(publisher).map { created ->
+            ResponseEntity.ok(created)
+        }
     }
 
     @PostMapping("/publisher-place", produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -128,8 +131,10 @@ class CoreController (
     ])
     fun createPublisherPlace(
         @RequestBody location: String
-    ): ResponseEntity<Mono<PublisherPlace>> {
-        return ResponseEntity.ok(axiellService.createPublisherPlace(location))
+    ): Mono<ResponseEntity<PublisherPlace>> {
+        return axiellService.createPublisherPlace(location).map { created ->
+            ResponseEntity.ok(created)
+        }
     }
 
     @PostMapping("/language", produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -141,10 +146,12 @@ class CoreController (
     ])
     fun createLanguage(
         @RequestBody language: String
-    ): ResponseEntity<Mono<PublisherPlace>> {
+    ): Mono<ResponseEntity<PublisherPlace>> {
         if (!Regex("^[a-z]{3}$").matches(language)) {
             throw BadRequestBodyException("Language code must be a valid ISO-639-2 language code.")
         }
-        return ResponseEntity.ok(axiellService.createLanguage(language))
+        return axiellService.createLanguage(language).map { created ->
+            ResponseEntity.ok(created)
+        }
     }
 }

--- a/src/main/kotlin/no/nb/bikube/core/enum/AxiellDatabase.kt
+++ b/src/main/kotlin/no/nb/bikube/core/enum/AxiellDatabase.kt
@@ -3,6 +3,6 @@ package no.nb.bikube.core.enum
 enum class AxiellDatabase (val value: String) {
     TEXTS("texts"),
     PEOPLE("people"),
-    LOCATIONS("theseaugeo"),
-    LANGUAGES("thesau")
+    LANGUAGES("thesau"),
+    LOCATIONS("thesaugeo")
 }

--- a/src/main/kotlin/no/nb/bikube/core/enum/AxiellDatabase.kt
+++ b/src/main/kotlin/no/nb/bikube/core/enum/AxiellDatabase.kt
@@ -1,0 +1,8 @@
+package no.nb.bikube.core.enum
+
+enum class AxiellDatabase (val value: String) {
+    TEXTS("texts"),
+    PEOPLE("people"),
+    LOCATIONS("theseaugeo"),
+    LANGUAGES("thesau")
+}

--- a/src/main/kotlin/no/nb/bikube/core/enum/AxiellType.kt
+++ b/src/main/kotlin/no/nb/bikube/core/enum/AxiellType.kt
@@ -15,3 +15,11 @@ enum class AxiellFormat(val value: String) {
     DIGITAL("DIGITAL"),
     PHYSICAL("PHYSICAL")
 }
+
+enum class AxiellNameType(val value: String) {
+    PUBLISHER("PUBLISHER")
+}
+
+enum class AxiellTermType(val value: String) {
+    LANGUAGE("LANGUAGE")
+}

--- a/src/main/kotlin/no/nb/bikube/core/enum/AxiellType.kt
+++ b/src/main/kotlin/no/nb/bikube/core/enum/AxiellType.kt
@@ -17,9 +17,10 @@ enum class AxiellFormat(val value: String) {
 }
 
 enum class AxiellNameType(val value: String) {
-    PUBLISHER("PUBLISHER")
+    PUBLISHER("PUBL")
 }
 
 enum class AxiellTermType(val value: String) {
-    LANGUAGE("LANGUAGE")
+    LANGUAGE("LANGUAGE"),
+    LOCATION("PLACE")
 }

--- a/src/main/kotlin/no/nb/bikube/core/enum/SearchType.kt
+++ b/src/main/kotlin/no/nb/bikube/core/enum/SearchType.kt
@@ -7,14 +7,3 @@ enum class SearchType (val value: String) {
     LANGUAGE("language"),
     LOCATION("location")
 }
-
-fun getSearchType(searchType: String): SearchType {
-    return when (searchType) {
-        "title" -> SearchType.TITLE
-        "item" -> SearchType.ITEM
-        "publisher" -> SearchType.PUBLISHER
-        "language" -> SearchType.LANGUAGE
-        "location" -> SearchType.LOCATION
-        else -> throw Exception("Search type $searchType is not supported.")
-    }
-}

--- a/src/main/kotlin/no/nb/bikube/core/enum/SearchType.kt
+++ b/src/main/kotlin/no/nb/bikube/core/enum/SearchType.kt
@@ -1,0 +1,20 @@
+package no.nb.bikube.core.enum
+
+enum class SearchType (val value: String) {
+    TITLE("title"),
+    ITEM("item"),
+    PUBLISHER("publisher"),
+    LANGUAGE("language"),
+    LOCATION("location")
+}
+
+fun getSearchType(searchType: String): SearchType {
+    return when (searchType) {
+        "title" -> SearchType.TITLE
+        "item" -> SearchType.ITEM
+        "publisher" -> SearchType.PUBLISHER
+        "language" -> SearchType.LANGUAGE
+        "location" -> SearchType.LOCATION
+        else -> throw Exception("Search type $searchType is not supported.")
+    }
+}

--- a/src/main/kotlin/no/nb/bikube/core/exception/BadRequestBodyException.kt
+++ b/src/main/kotlin/no/nb/bikube/core/exception/BadRequestBodyException.kt
@@ -1,0 +1,3 @@
+package no.nb.bikube.core.exception
+
+class BadRequestBodyException (message: String): Exception(message)

--- a/src/main/kotlin/no/nb/bikube/core/exception/GlobalControllerExceptionHandler.kt
+++ b/src/main/kotlin/no/nb/bikube/core/exception/GlobalControllerExceptionHandler.kt
@@ -42,6 +42,17 @@ class GlobalControllerExceptionHandler {
 
         return problemDetail
     }
+
+    @ExceptionHandler(BadRequestBodyException::class)
+    fun handleBadRequestBodyException(exception: BadRequestBodyException): ProblemDetail {
+        logger().warn("BadRequestBodyException occurred: ${exception.message}")
+
+        val problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST)
+        problemDetail.detail = exception.message ?: "The request body is malformed."
+        problemDetail.addDefaultProperties()
+
+        return problemDetail
+    }
 }
 
 fun ProblemDetail.addDefaultProperties() {

--- a/src/main/kotlin/no/nb/bikube/core/exception/GlobalControllerExceptionHandler.kt
+++ b/src/main/kotlin/no/nb/bikube/core/exception/GlobalControllerExceptionHandler.kt
@@ -53,6 +53,17 @@ class GlobalControllerExceptionHandler {
 
         return problemDetail
     }
+
+    @ExceptionHandler(RecordAlreadyExistsException::class)
+    fun handleRecordAlreadyExistsException(exception: RecordAlreadyExistsException): ProblemDetail {
+        logger().warn("RecordAlreadyExistsException occurred: ${exception.message}")
+
+        val problemDetail = ProblemDetail.forStatus(HttpStatus.CONFLICT)
+        problemDetail.detail = exception.message ?: "The record already exists."
+        problemDetail.addDefaultProperties()
+
+        return problemDetail
+    }
 }
 
 fun ProblemDetail.addDefaultProperties() {

--- a/src/main/kotlin/no/nb/bikube/core/exception/RecordAlreadyExistsException.kt
+++ b/src/main/kotlin/no/nb/bikube/core/exception/RecordAlreadyExistsException.kt
@@ -1,0 +1,3 @@
+package no.nb.bikube.core.exception
+
+class RecordAlreadyExistsException(message: String): Exception(message)

--- a/src/main/kotlin/no/nb/bikube/core/mapper/LanguageMapper.kt
+++ b/src/main/kotlin/no/nb/bikube/core/mapper/LanguageMapper.kt
@@ -1,0 +1,11 @@
+package no.nb.bikube.core.mapper
+
+import no.nb.bikube.core.model.CollectionsObject
+import no.nb.bikube.core.model.Language
+
+fun mapCollectionsObjectToGenericLanguage(model: CollectionsObject): Language {
+    return Language(
+        name = model.term,
+        catalogueId = model.priRef
+    )
+}

--- a/src/main/kotlin/no/nb/bikube/core/mapper/LanguageMapper.kt
+++ b/src/main/kotlin/no/nb/bikube/core/mapper/LanguageMapper.kt
@@ -1,11 +1,11 @@
 package no.nb.bikube.core.mapper
 
-import no.nb.bikube.core.model.CollectionsObject
+import no.nb.bikube.core.model.CollectionsTermObject
 import no.nb.bikube.core.model.Language
 
-fun mapCollectionsObjectToGenericLanguage(model: CollectionsObject): Language {
+fun mapCollectionsObjectToGenericLanguage(model: CollectionsTermObject): Language {
     return Language(
         name = model.term,
-        catalogueId = model.priRef
+        databaseId = model.priRef
     )
 }

--- a/src/main/kotlin/no/nb/bikube/core/mapper/PublisherMapper.kt
+++ b/src/main/kotlin/no/nb/bikube/core/mapper/PublisherMapper.kt
@@ -1,11 +1,11 @@
 package no.nb.bikube.core.mapper
 
-import no.nb.bikube.core.model.CollectionsObject
+import no.nb.bikube.core.model.CollectionsNameObject
 import no.nb.bikube.core.model.Publisher
 
-fun mapCollectionsObjectToGenericPublisher(model: CollectionsObject): Publisher {
+fun mapCollectionsObjectToGenericPublisher(model: CollectionsNameObject): Publisher {
     return Publisher(
         name = model.name,
-        catalogueId = model.priRef
+        databaseId = model.priRef
     )
 }

--- a/src/main/kotlin/no/nb/bikube/core/mapper/PublisherMapper.kt
+++ b/src/main/kotlin/no/nb/bikube/core/mapper/PublisherMapper.kt
@@ -1,0 +1,11 @@
+package no.nb.bikube.core.mapper
+
+import no.nb.bikube.core.model.CollectionsObject
+import no.nb.bikube.core.model.Publisher
+
+fun mapCollectionsObjectToGenericPublisher(model: CollectionsObject): Publisher {
+    return Publisher(
+        name = model.name,
+        catalogueId = model.priRef
+    )
+}

--- a/src/main/kotlin/no/nb/bikube/core/mapper/PublisherPlaceMapper.kt
+++ b/src/main/kotlin/no/nb/bikube/core/mapper/PublisherPlaceMapper.kt
@@ -1,0 +1,11 @@
+package no.nb.bikube.core.mapper
+
+import no.nb.bikube.core.model.CollectionsObject
+import no.nb.bikube.core.model.PublisherPlace
+
+fun mapCollectionsObjectToGenericPublisherPlace(model: CollectionsObject): PublisherPlace {
+    return PublisherPlace(
+        name = model.term,
+        catalogueId = model.priRef
+    )
+}

--- a/src/main/kotlin/no/nb/bikube/core/mapper/PublisherPlaceMapper.kt
+++ b/src/main/kotlin/no/nb/bikube/core/mapper/PublisherPlaceMapper.kt
@@ -1,11 +1,11 @@
 package no.nb.bikube.core.mapper
 
-import no.nb.bikube.core.model.CollectionsObject
+import no.nb.bikube.core.model.CollectionsTermObject
 import no.nb.bikube.core.model.PublisherPlace
 
-fun mapCollectionsObjectToGenericPublisherPlace(model: CollectionsObject): PublisherPlace {
+fun mapCollectionsObjectToGenericPublisherPlace(model: CollectionsTermObject): PublisherPlace {
     return PublisherPlace(
         name = model.term,
-        catalogueId = model.priRef
+        databaseId = model.priRef
     )
 }

--- a/src/main/kotlin/no/nb/bikube/core/model/CatalogueRecord.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/CatalogueRecord.kt
@@ -1,0 +1,3 @@
+package no.nb.bikube.core.model
+
+sealed interface CatalogueRecord

--- a/src/main/kotlin/no/nb/bikube/core/model/CollectionsNameObject.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/CollectionsNameObject.kt
@@ -1,0 +1,34 @@
+package no.nb.bikube.core.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class CollectionsNameModel(
+    @JsonProperty("adlibJSON")
+    val adlibJson: CollectionsNameRecordList
+)
+
+data class CollectionsNameRecordList(
+    val recordList: List<CollectionsNameObject>?
+)
+
+data class CollectionsNameObject(
+    @JsonProperty("priref")
+    val priRef: String? = null,
+
+    val name: String,
+
+    @JsonProperty("name.type")
+    val nameType: String? = null,
+
+    @JsonProperty("input.date")
+    val inputDate: String? = null,
+
+    @JsonProperty("input.time")
+    val inputTime: String? = null,
+
+    @JsonProperty("input.source")
+    val inputSource: String? = null,
+
+    @JsonProperty("input.name")
+    val inputName: String? = null
+)

--- a/src/main/kotlin/no/nb/bikube/core/model/CollectionsNameObject.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/CollectionsNameObject.kt
@@ -12,23 +12,9 @@ data class CollectionsNameRecordList(
 )
 
 data class CollectionsNameObject(
-    @JsonProperty("priref")
-    val priRef: String? = null,
+    @JsonProperty("@priref")
+    val priRef: String?,
 
+    @JsonProperty("name")
     val name: String,
-
-    @JsonProperty("name.type")
-    val nameType: String? = null,
-
-    @JsonProperty("input.date")
-    val inputDate: String? = null,
-
-    @JsonProperty("input.time")
-    val inputTime: String? = null,
-
-    @JsonProperty("input.source")
-    val inputSource: String? = null,
-
-    @JsonProperty("input.name")
-    val inputName: String? = null
 )

--- a/src/main/kotlin/no/nb/bikube/core/model/CollectionsObject.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/CollectionsObject.kt
@@ -16,7 +16,9 @@ data class CollectionsObject(
     @JsonProperty("@priref")
     val priRef: String,
 
-    val name: String?,
+    val name: String? = null,
+
+    val term: String? = null,
 
     @JsonProperty("Title")
     val titleList: List<CollectionsTitle>?,

--- a/src/main/kotlin/no/nb/bikube/core/model/CollectionsObject.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/CollectionsObject.kt
@@ -16,10 +16,6 @@ data class CollectionsObject(
     @JsonProperty("@priref")
     val priRef: String,
 
-    val name: String? = null,
-
-    val term: String? = null,
-
     @JsonProperty("Title")
     val titleList: List<CollectionsTitle>?,
 
@@ -54,7 +50,8 @@ data class CollectionsObject(
     val partsList: List<CollectionsPartsObject>?,
 
     @JsonProperty("work.description_type")
-    val workTypeList: List<List<CollectionsLanguageListObject>>?)
+    val workTypeList: List<List<CollectionsLanguageListObject>>?
+)
 
 data class CollectionsTitle(
     val title: String?

--- a/src/main/kotlin/no/nb/bikube/core/model/CollectionsObject.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/CollectionsObject.kt
@@ -16,6 +16,8 @@ data class CollectionsObject(
     @JsonProperty("@priref")
     val priRef: String,
 
+    val name: String?,
+
     @JsonProperty("Title")
     val titleList: List<CollectionsTitle>?,
 

--- a/src/main/kotlin/no/nb/bikube/core/model/CollectionsTermObject.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/CollectionsTermObject.kt
@@ -12,24 +12,9 @@ data class CollectionsTermRecordList(
 )
 
 data class CollectionsTermObject(
-    @JsonProperty("priref")
-    val priRef: String? = null,
+    @JsonProperty("@priref")
+    val priRef: String,
 
     @JsonProperty("term")
     val term: String,
-
-    @JsonProperty("term.type")
-    val termType: String? = null,
-
-    @JsonProperty("input.date")
-    val inputDate: String? = null,
-
-    @JsonProperty("input.time")
-    val inputTime: String? = null,
-
-    @JsonProperty("input.source")
-    val inputSource: String? = null,
-
-    @JsonProperty("input.name")
-    val inputName: String? = null
 )

--- a/src/main/kotlin/no/nb/bikube/core/model/CollectionsTermObject.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/CollectionsTermObject.kt
@@ -1,0 +1,35 @@
+package no.nb.bikube.core.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class CollectionsTermModel(
+    @JsonProperty("adlibJSON")
+    val adlibJson: CollectionsTermRecordList
+)
+
+data class CollectionsTermRecordList(
+    val recordList: List<CollectionsTermObject>?
+)
+
+data class CollectionsTermObject(
+    @JsonProperty("priref")
+    val priRef: String? = null,
+
+    @JsonProperty("term")
+    val term: String,
+
+    @JsonProperty("term.type")
+    val termType: String? = null,
+
+    @JsonProperty("input.date")
+    val inputDate: String? = null,
+
+    @JsonProperty("input.time")
+    val inputTime: String? = null,
+
+    @JsonProperty("input.source")
+    val inputSource: String? = null,
+
+    @JsonProperty("input.name")
+    val inputName: String? = null
+)

--- a/src/main/kotlin/no/nb/bikube/core/model/Language.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/Language.kt
@@ -2,5 +2,5 @@ package no.nb.bikube.core.model
 
 data class Language(
     val name: String?,
-    val catalogueId: String?
+    val databaseId: String?
 ) : CatalogueRecord

--- a/src/main/kotlin/no/nb/bikube/core/model/Language.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/Language.kt
@@ -1,0 +1,6 @@
+package no.nb.bikube.core.model
+
+data class Language(
+    val name: String?,
+    val catalogueId: String?
+) : CatalogueRecord

--- a/src/main/kotlin/no/nb/bikube/core/model/Publisher.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/Publisher.kt
@@ -2,5 +2,5 @@ package no.nb.bikube.core.model
 
 data class Publisher(
     val name: String?,
-    val catalogueId: String?
+    val databaseId: String?
 ) : CatalogueRecord

--- a/src/main/kotlin/no/nb/bikube/core/model/Publisher.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/Publisher.kt
@@ -1,0 +1,6 @@
+package no.nb.bikube.core.model
+
+data class Publisher(
+    val name: String?,
+    val catalogueId: String?
+) : CatalogueRecord

--- a/src/main/kotlin/no/nb/bikube/core/model/PublisherPlace.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/PublisherPlace.kt
@@ -1,0 +1,6 @@
+package no.nb.bikube.core.model
+
+data class PublisherPlace(
+    val name: String?,
+    val catalogueId: String?
+) : CatalogueRecord

--- a/src/main/kotlin/no/nb/bikube/core/model/PublisherPlace.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/PublisherPlace.kt
@@ -2,5 +2,5 @@ package no.nb.bikube.core.model
 
 data class PublisherPlace(
     val name: String?,
-    val catalogueId: String?
+    val databaseId: String?
 ) : CatalogueRecord

--- a/src/main/kotlin/no/nb/bikube/core/model/Title.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/Title.kt
@@ -2,7 +2,7 @@ package no.nb.bikube.core.model
 
 import java.time.LocalDate
 
-data class Title (
+data class Title(
     val name: String?,
     val startDate: LocalDate?,
     val endDate: LocalDate?,
@@ -11,4 +11,4 @@ data class Title (
     val language: String?,
     val materialType: String?,
     val catalogueId: String?
-)
+) : CatalogueRecord

--- a/src/main/kotlin/no/nb/bikube/core/model/dto/AxiellNameRecordDto.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/dto/AxiellNameRecordDto.kt
@@ -1,0 +1,33 @@
+package no.nb.bikube.core.model.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import no.nb.bikube.core.enum.AxiellNameType
+import java.time.LocalDate
+
+// TODO: Do we need GUID, input.source, input.name?
+@Serializable
+class AxiellNameRecordDto(
+    val name: String,
+
+    @SerialName("name.type")
+    val nameType: String? = null,
+
+    @SerialName("input.date")
+    val inputDate: String? = null,
+
+    @SerialName("input.name")
+    val inputName: String? = null,
+
+    @SerialName("priref")
+    val catalogueId: String? = null
+)
+
+fun createNameRecordDtoFromString(name: String): AxiellNameRecordDto {
+    return AxiellNameRecordDto(
+        name = name,
+        nameType = AxiellNameType.PUBLISHER.value,
+        inputDate = LocalDate.now().toString(),
+        inputName = "Bikube API" // TODO: Change when we have authentication in place
+    )
+}

--- a/src/main/kotlin/no/nb/bikube/core/model/dto/AxiellNameRecordDto.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/dto/AxiellNameRecordDto.kt
@@ -4,8 +4,9 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import no.nb.bikube.core.enum.AxiellNameType
 import java.time.LocalDate
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
 
-// TODO: Do we need GUID, input.source, input.name?
 @Serializable
 class AxiellNameRecordDto(
     val name: String,
@@ -16,11 +17,14 @@ class AxiellNameRecordDto(
     @SerialName("input.date")
     val inputDate: String? = null,
 
+    @SerialName("input.time")
+    val inputTime: String? = null,
+
     @SerialName("input.name")
     val inputName: String? = null,
 
     @SerialName("priref")
-    val catalogueId: String? = null
+    val priRef: String? = null
 )
 
 fun createNameRecordDtoFromString(name: String): AxiellNameRecordDto {
@@ -28,6 +32,7 @@ fun createNameRecordDtoFromString(name: String): AxiellNameRecordDto {
         name = name,
         nameType = AxiellNameType.PUBLISHER.value,
         inputDate = LocalDate.now().toString(),
+        inputTime = LocalTime.now().format(DateTimeFormatter.ofPattern("HH:mm:ss")).toString(),
         inputName = "Bikube API" // TODO: Change when we have authentication in place
     )
 }

--- a/src/main/kotlin/no/nb/bikube/core/model/dto/AxiellTermRecordDto.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/dto/AxiellTermRecordDto.kt
@@ -1,0 +1,47 @@
+package no.nb.bikube.core.model.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import no.nb.bikube.core.enum.AxiellTermType
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+
+@Serializable
+class AxiellTermRecordDto(
+    @SerialName("term")
+    val term: String,
+
+    @SerialName("term.type")
+    val termType: String? = null,
+
+    @SerialName("input.date")
+    val inputDate: String? = null,
+
+    @SerialName("input.time")
+    val inputTime: String? = null,
+
+    @SerialName("input.source")
+    val inputSource: String? = null,
+
+    @SerialName("input.name")
+    val inputName: String? = null,
+
+    @SerialName("priref")
+    val priRef: String? = null
+)
+
+fun createTermRecordDtoFromString(termName: String): AxiellTermRecordDto {
+    return AxiellTermRecordDto(
+        term = termName,
+        termType = AxiellTermType.LANGUAGE.value,
+        inputDate = LocalDate.now().toString(),
+        inputTime = LocalTime.now().format(DateTimeFormatter.ofPattern("HH:mm:ss")).toString(),
+        inputName = "Bikube API" // TODO: Change when we have authentication in place
+    )
+}
+
+
+
+
+

--- a/src/main/kotlin/no/nb/bikube/core/model/dto/AxiellTermRecordDto.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/dto/AxiellTermRecordDto.kt
@@ -31,10 +31,10 @@ class AxiellTermRecordDto(
     val priRef: String? = null
 )
 
-fun createTermRecordDtoFromString(termName: String): AxiellTermRecordDto {
+fun createTermRecordDtoFromString(termName: String, termType: AxiellTermType): AxiellTermRecordDto {
     return AxiellTermRecordDto(
         term = termName,
-        termType = AxiellTermType.LANGUAGE.value,
+        termType = termType.value,
         inputDate = LocalDate.now().toString(),
         inputTime = LocalTime.now().format(DateTimeFormatter.ofPattern("HH:mm:ss")).toString(),
         inputName = "Bikube API" // TODO: Change when we have authentication in place

--- a/src/main/kotlin/no/nb/bikube/core/model/dto/AxiellTermRecordDto.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/dto/AxiellTermRecordDto.kt
@@ -40,8 +40,3 @@ fun createTermRecordDtoFromString(termName: String, termType: AxiellTermType): A
         inputName = "Bikube API" // TODO: Change when we have authentication in place
     )
 }
-
-
-
-
-

--- a/src/main/kotlin/no/nb/bikube/core/model/dto/TitleDto.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/dto/TitleDto.kt
@@ -2,6 +2,9 @@ package no.nb.bikube.core.model.dto
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import no.nb.bikube.core.enum.AxiellDescriptionType
+import no.nb.bikube.core.enum.AxiellRecordType
+import no.nb.bikube.core.model.Title
 
 @Serializable
 class TitleDto(
@@ -31,3 +34,17 @@ class TitleDto(
     @SerialName("language")
     val language: String? = null
 )
+
+fun createNewspaperTitleDto(title: Title): TitleDto {
+    return TitleDto(
+        title = title.name!!,
+        dateStart = title.startDate?.toString(),
+        dateEnd = title.endDate?.toString(),
+        publisher = title.publisher,
+        placeOfPublication = title.publisherPlace,
+        language = title.language,
+        recordType = AxiellRecordType.WORK.value,
+        descriptionType = AxiellDescriptionType.SERIAL.value,
+        subMedium = title.materialType
+    )
+}

--- a/src/main/kotlin/no/nb/bikube/core/model/dto/TitleDto.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/dto/TitleDto.kt
@@ -28,6 +28,9 @@ class TitleDto(
     @SerialName("place_of_publication")
     val placeOfPublication: String? = null,
 
+    @SerialName("place_of_publication.lref")
+    val placeOfPublicationRef: String? = null,
+
     @SerialName("language")
     val language: String? = null
 )

--- a/src/main/kotlin/no/nb/bikube/core/model/dto/TitleDto.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/dto/TitleDto.kt
@@ -16,6 +16,9 @@ class TitleDto(
     @SerialName("work.description_type")
     val descriptionType: String?,
 
+    @SerialName("medium")
+    val medium: String? = null,
+
     @SerialName("submedium")
     val subMedium: String? = null,
 
@@ -45,6 +48,7 @@ fun createNewspaperTitleDto(title: Title): TitleDto {
         language = title.language,
         recordType = AxiellRecordType.WORK.value,
         descriptionType = AxiellDescriptionType.SERIAL.value,
+        medium = "Tekst",
         subMedium = title.materialType
     )
 }

--- a/src/main/kotlin/no/nb/bikube/core/model/dto/TitleDto.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/dto/TitleDto.kt
@@ -1,4 +1,4 @@
-package no.nb.bikube.core.model
+package no.nb.bikube.core.model.dto
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/src/main/kotlin/no/nb/bikube/core/model/dto/TitleDto.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/dto/TitleDto.kt
@@ -28,9 +28,6 @@ class TitleDto(
     @SerialName("place_of_publication")
     val placeOfPublication: String? = null,
 
-    @SerialName("place_of_publication.lref")
-    val placeOfPublicationRef: String? = null,
-
     @SerialName("language")
     val language: String? = null
 )

--- a/src/main/kotlin/no/nb/bikube/newspaper/controller/TitleController.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/controller/TitleController.kt
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
-import kotlinx.coroutines.reactive.collect
 import no.nb.bikube.core.exception.AxiellCollectionsException
 import no.nb.bikube.core.exception.BadRequestBodyException
 import no.nb.bikube.core.exception.RecordAlreadyExistsException
@@ -13,7 +12,6 @@ import no.nb.bikube.core.model.Publisher
 import no.nb.bikube.core.model.PublisherPlace
 import no.nb.bikube.core.model.Title
 import no.nb.bikube.newspaper.service.AxiellService
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*

--- a/src/main/kotlin/no/nb/bikube/newspaper/controller/TitleController.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/controller/TitleController.kt
@@ -43,6 +43,12 @@ class TitleController (
         if (title.name.isNullOrEmpty()) {
             return ResponseEntity.badRequest().build()
         }
+
+        if (!title.publisher.isNullOrEmpty()) {
+            axiellService.searchPublisherByName(title.publisher)
+            // TODO: Search for publisher and create if not found
+        }
+
         return ResponseEntity.ok(axiellService.createTitle(title))
     }
 }

--- a/src/main/kotlin/no/nb/bikube/newspaper/repository/AxiellRepository.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/repository/AxiellRepository.kt
@@ -1,6 +1,8 @@
 package no.nb.bikube.newspaper.repository
 
+import no.nb.bikube.core.enum.AxiellDatabase
 import no.nb.bikube.core.enum.AxiellDescriptionType
+import no.nb.bikube.core.enum.AxiellNameType
 import no.nb.bikube.core.enum.AxiellRecordType
 import no.nb.bikube.core.exception.AxiellCollectionsException
 import no.nb.bikube.core.model.CollectionsModel
@@ -43,6 +45,13 @@ class AxiellRepository(
         )
     }
 
+    fun searchPublisher(name: String): Mono<CollectionsModel> {
+        return searchTexts(
+            "name.type=${AxiellNameType.PUBLISHER} and name=\"${name}\"",
+            AxiellDatabase.PEOPLE
+        )
+    }
+
     @Throws(AxiellCollectionsException::class)
     fun createTitle(serializedBody: String): Mono<CollectionsModel> {
         return webClient()
@@ -65,12 +74,15 @@ class AxiellRepository(
     }
 
     @Throws(AxiellCollectionsException::class)
-    private fun searchTexts(searchQuery: String): Mono<CollectionsModel> {
+    private fun searchTexts(
+        searchQuery: String,
+        database: AxiellDatabase? = AxiellDatabase.TEXTS
+    ): Mono<CollectionsModel> {
         return webClient()
             .get()
             .uri {
                 it
-                    .queryParam("database", "texts")
+                    .queryParam("database", database)
                     .queryParam("output", "json")
                     .queryParam("search", searchQuery)
                     .build()

--- a/src/main/kotlin/no/nb/bikube/newspaper/repository/AxiellRepository.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/repository/AxiellRepository.kt
@@ -46,10 +46,7 @@ class AxiellRepository(
     }
 
     fun searchPublisher(name: String): Mono<CollectionsNameModel> {
-        return searchNameDatabases(
-            "name.type=${AxiellNameType.PUBLISHER} and name=\"${name}\"",
-            AxiellDatabase.PEOPLE
-        )
+        return searchNameDatabases("name.type=${AxiellNameType.PUBLISHER} and name=\"${name}\"")
     }
 
     fun searchLanguage(name: String): Mono<CollectionsTermModel> {
@@ -80,8 +77,8 @@ class AxiellRepository(
         return getRecordsWebClientRequest(query, AxiellDatabase.TEXTS).bodyToMono<CollectionsModel>()
     }
 
-    private fun searchNameDatabases(query: String, db: AxiellDatabase): Mono<CollectionsNameModel> {
-        return getRecordsWebClientRequest(query, db).bodyToMono<CollectionsNameModel>()
+    private fun searchNameDatabases(query: String): Mono<CollectionsNameModel> {
+        return getRecordsWebClientRequest(query, AxiellDatabase.PEOPLE).bodyToMono<CollectionsNameModel>()
     }
 
     private fun searchTermDatabases(query: String, db: AxiellDatabase): Mono<CollectionsTermModel> {
@@ -103,7 +100,7 @@ class AxiellRepository(
                 { !it.is2xxSuccessful },
                 {
                     logger().error(
-                        "Could not search in Collections catalogue. Error code ${it.statusCode()}"
+                        "Could not search in Collections ${db.value} catalogue. Error code ${it.statusCode()}"
                     )
                     Mono.error(AxiellCollectionsException(
                         "Could not search in Collections catalogue. Try again later or contact Team Text if the problem persists."

--- a/src/main/kotlin/no/nb/bikube/newspaper/repository/AxiellRepository.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/repository/AxiellRepository.kt
@@ -65,8 +65,6 @@ class AxiellRepository(
         serializedBody: String,
         database: String? = AxiellDatabase.TEXTS.value
     ): Mono<CollectionsModel> {
-        println("serializedBody: $serializedBody")
-        println("database: $database")
         return webClient()
             .post()
             .uri {

--- a/src/main/kotlin/no/nb/bikube/newspaper/repository/AxiellRepository.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/repository/AxiellRepository.kt
@@ -1,9 +1,6 @@
 package no.nb.bikube.newspaper.repository
 
-import no.nb.bikube.core.enum.AxiellDatabase
-import no.nb.bikube.core.enum.AxiellDescriptionType
-import no.nb.bikube.core.enum.AxiellNameType
-import no.nb.bikube.core.enum.AxiellRecordType
+import no.nb.bikube.core.enum.*
 import no.nb.bikube.core.exception.AxiellCollectionsException
 import no.nb.bikube.core.model.CollectionsModel
 import no.nb.bikube.core.util.logger
@@ -48,17 +45,31 @@ class AxiellRepository(
     fun searchPublisher(name: String): Mono<CollectionsModel> {
         return searchTexts(
             "name.type=${AxiellNameType.PUBLISHER} and name=\"${name}\"",
-            AxiellDatabase.PEOPLE
+            AxiellDatabase.PEOPLE.value
         )
     }
 
+    fun searchLanguage(name: String): Mono<CollectionsModel> {
+        return searchTexts(
+            "term.type=${AxiellTermType.LANGUAGE} and term=\"${name}\"",
+            AxiellDatabase.LANGUAGES.value
+        )
+    }
+
+    fun searchPublisherPlace(name: String): Mono<CollectionsModel> {
+        return searchTexts("term=\"${name}\"", AxiellDatabase.LOCATIONS.value)
+    }
+
     @Throws(AxiellCollectionsException::class)
-    fun createTitle(serializedBody: String): Mono<CollectionsModel> {
+    fun createRecord(
+        serializedBody: String,
+        database: String? = AxiellDatabase.TEXTS.value
+    ): Mono<CollectionsModel> {
         return webClient()
             .post()
             .uri {
                 it
-                    .queryParam("database", "texts")
+                    .queryParam("database", database)
                     .queryParam("command", "insertrecord")
                     .queryParam("output", "json")
                     .build()
@@ -76,7 +87,7 @@ class AxiellRepository(
     @Throws(AxiellCollectionsException::class)
     private fun searchTexts(
         searchQuery: String,
-        database: AxiellDatabase? = AxiellDatabase.TEXTS
+        database: String? = AxiellDatabase.TEXTS.value
     ): Mono<CollectionsModel> {
         return webClient()
             .get()

--- a/src/main/kotlin/no/nb/bikube/newspaper/repository/AxiellRepository.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/repository/AxiellRepository.kt
@@ -65,6 +65,8 @@ class AxiellRepository(
         serializedBody: String,
         database: String? = AxiellDatabase.TEXTS.value
     ): Mono<CollectionsModel> {
+        println("serializedBody: $serializedBody")
+        println("database: $database")
         return webClient()
             .post()
             .uri {

--- a/src/main/kotlin/no/nb/bikube/newspaper/service/AxiellService.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/service/AxiellService.kt
@@ -7,6 +7,7 @@ import no.nb.bikube.core.enum.AxiellRecordType
 import no.nb.bikube.core.exception.AxiellCollectionsException
 import no.nb.bikube.core.exception.AxiellTitleNotFound
 import no.nb.bikube.core.mapper.mapCollectionsObjectToGenericItem
+import no.nb.bikube.core.mapper.mapCollectionsObjectToGenericPublisher
 import no.nb.bikube.core.mapper.mapCollectionsObjectToGenericTitle
 import no.nb.bikube.core.mapper.mapCollectionsPartsObjectToGenericItem
 import no.nb.bikube.core.model.*
@@ -114,10 +115,16 @@ class AxiellService  (
             }
     }
 
-    fun getTitleByName(name: String): Flux<Title> {
+    fun searchTitleByName(name: String): Flux<CatalogueRecord> {
         return axiellRepository.getTitleByName(name)
             .flatMapIterable { it.adlibJson.recordList ?: emptyList() }
             .map { mapCollectionsObjectToGenericTitle(it) }
+    }
+
+    fun searchPublisherByName(name: String): Flux<CatalogueRecord> {
+        return axiellRepository.searchPublisher(name)
+            .flatMapIterable { it.adlibJson.recordList ?: emptyList() }
+            .map { mapCollectionsObjectToGenericPublisher(it) }
     }
 
     @Throws(AxiellCollectionsException::class, AxiellTitleNotFound::class)

--- a/src/main/kotlin/no/nb/bikube/newspaper/service/AxiellService.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/service/AxiellService.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.json.Json
 import no.nb.bikube.core.enum.*
 import no.nb.bikube.core.exception.AxiellCollectionsException
 import no.nb.bikube.core.exception.AxiellTitleNotFound
+import no.nb.bikube.core.exception.BadRequestBodyException
 import no.nb.bikube.core.exception.RecordAlreadyExistsException
 import no.nb.bikube.core.mapper.*
 import no.nb.bikube.core.model.*
@@ -139,6 +140,7 @@ class AxiellService  (
     }
 
     fun createPublisher(publisher: String): Mono<Publisher> {
+        if (publisher.isEmpty()) throw BadRequestBodyException("Publisher cannot be empty.")
         val serializedBody = Json.encodeToString(createNameRecordDtoFromString(publisher))
         return axiellRepository.searchPublisher(publisher)
             .flatMap { collectionsModel ->
@@ -152,6 +154,7 @@ class AxiellService  (
     }
 
     fun createPublisherPlace(publisherPlace: String): Mono<PublisherPlace> {
+        if (publisherPlace.isEmpty()) throw BadRequestBodyException("Publisher place cannot be empty.")
         val serializedBody = Json.encodeToString(createTermRecordDtoFromString(publisherPlace, AxiellTermType.LOCATION))
         return axiellRepository.searchPublisherPlace(publisherPlace)
             .flatMap { collectionsModel ->
@@ -165,6 +168,9 @@ class AxiellService  (
     }
 
     fun createLanguage(language: String): Mono<Language> {
+        if (!Regex("^[a-z]{3}$").matches(language)) {
+            throw BadRequestBodyException("Language code must be a valid ISO-639-2 language code.")
+        }
         val serializedBody = Json.encodeToString(createTermRecordDtoFromString(language, AxiellTermType.LANGUAGE))
         return axiellRepository.searchLanguage(language)
             .flatMap { collectionsModel ->

--- a/src/main/kotlin/no/nb/bikube/newspaper/service/AxiellService.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/service/AxiellService.kt
@@ -43,7 +43,6 @@ class AxiellService  (
             )
         )
         return axiellRepository.createRecord(encodedBody)
-            .doOnNext{println(it)}
             .handle { collectionsModel, sink: SynchronousSink<List<CollectionsObject>> ->
                 collectionsModel.adlibJson.recordList
                     ?. let { sink.next(collectionsModel.adlibJson.recordList) }
@@ -165,7 +164,7 @@ class AxiellService  (
             }
     }
 
-    fun createLanguage(language: String): Mono<PublisherPlace> {
+    fun createLanguage(language: String): Mono<Language> {
         val serializedBody = Json.encodeToString(createTermRecordDtoFromString(language, AxiellTermType.LANGUAGE))
         return axiellRepository.searchLanguage(language)
             .flatMap { collectionsModel ->
@@ -173,7 +172,7 @@ class AxiellService  (
                     Mono.error(RecordAlreadyExistsException("Language '$language' already exists"))
                 } else {
                     axiellRepository.createRecord(serializedBody, AxiellDatabase.LANGUAGES.value)
-                        .map { mapCollectionsObjectToGenericPublisherPlace(it.adlibJson.recordList!!.first()) }
+                        .map { mapCollectionsObjectToGenericLanguage(it.adlibJson.recordList!!.first()) }
                 }
             }
     }

--- a/src/test/kotlin/no/nb/bikube/core/CollectionsModelMockData.kt
+++ b/src/test/kotlin/no/nb/bikube/core/CollectionsModelMockData.kt
@@ -214,6 +214,7 @@ class CollectionsModelMockData {
             )
         )
 
+        // Equal to newspaperTitleMockB
         val collectionsModelMockTitleE = CollectionsModel(
             adlibJson = CollectionsRecordList(
                 recordList = listOf(CollectionsObject(
@@ -321,6 +322,28 @@ class CollectionsModelMockData {
                 recordList = listOf(
                     CollectionsObject(
                         priRef = "25",
+                        titleList = listOf(CollectionsTitle(title = "Bikubeavisen 1999")),
+                        recordTypeList = collectionsRecordTypeListWorkMock,
+                        formatList = null,
+                        partOfList = listOf(collectionsPartOfObjectMockSerialWorkA),
+                        subMediumList = null,
+                        mediumList = null,
+                        datingList = null,
+                        publisherList = null,
+                        languageList = null,
+                        placeOfPublicationList = null,
+                        partsList = listOf(collectionsPartsObjectMockManifestationA),
+                        workTypeList = collectionsWorkTypeListYearMock
+                    )
+                )
+            )
+        )
+        val collectionsModelMockWithNameA = CollectionsModel(
+            adlibJson = CollectionsRecordList(
+                recordList = listOf(
+                    CollectionsObject(
+                        priRef = "26",
+                        name = "Bikubeavisen 1999",
                         titleList = listOf(CollectionsTitle(title = "Bikubeavisen 1999")),
                         recordTypeList = collectionsRecordTypeListWorkMock,
                         formatList = null,

--- a/src/test/kotlin/no/nb/bikube/core/CollectionsModelMockData.kt
+++ b/src/test/kotlin/no/nb/bikube/core/CollectionsModelMockData.kt
@@ -342,11 +342,6 @@ class CollectionsModelMockData {
                     CollectionsNameObject(
                         priRef = "123",
                         name = "Schibsted",
-                        nameType = AxiellNameType.PUBLISHER.value,
-                        inputDate = "2020-01-01",
-                        inputTime = "12:00:00",
-                        inputName = "Bikube API",
-                        inputSource = "thesau>thesau"
                     )
                 )
             )
@@ -357,11 +352,6 @@ class CollectionsModelMockData {
                     CollectionsTermObject(
                         priRef = "123",
                         term = "nob",
-                        termType = AxiellTermType.LANGUAGE.value,
-                        inputDate = "2020-01-01",
-                        inputTime = "12:00:00",
-                        inputName = "Bikube API",
-                        inputSource = "thesau>thesau"
                     )
                 )
             )
@@ -372,11 +362,6 @@ class CollectionsModelMockData {
                     CollectionsTermObject(
                         priRef = "123",
                         term = "Oslo",
-                        termType = AxiellTermType.LOCATION.value,
-                        inputDate = "2020-01-01",
-                        inputTime = "12:00:00",
-                        inputName = "Bikube API",
-                        inputSource = "thesaugeo>thesaugeo"
                     )
                 )
             )

--- a/src/test/kotlin/no/nb/bikube/core/CollectionsModelMockData.kt
+++ b/src/test/kotlin/no/nb/bikube/core/CollectionsModelMockData.kt
@@ -1,8 +1,6 @@
 package no.nb.bikube.core
 
-import no.nb.bikube.core.enum.AxiellDescriptionType
-import no.nb.bikube.core.enum.AxiellFormat
-import no.nb.bikube.core.enum.AxiellRecordType
+import no.nb.bikube.core.enum.*
 import no.nb.bikube.core.model.*
 
 class CollectionsModelMockData {
@@ -338,27 +336,56 @@ class CollectionsModelMockData {
                 )
             )
         )
-        val collectionsModelMockWithNameA = CollectionsModel(
-            adlibJson = CollectionsRecordList(
+        val collectionsNameModelMockA = CollectionsNameModel(
+            adlibJson = CollectionsNameRecordList(
                 recordList = listOf(
-                    CollectionsObject(
-                        priRef = "26",
-                        name = "Bikubeavisen 1999",
-                        titleList = listOf(CollectionsTitle(title = "Bikubeavisen 1999")),
-                        recordTypeList = collectionsRecordTypeListWorkMock,
-                        formatList = null,
-                        partOfList = listOf(collectionsPartOfObjectMockSerialWorkA),
-                        subMediumList = null,
-                        mediumList = null,
-                        datingList = null,
-                        publisherList = null,
-                        languageList = null,
-                        placeOfPublicationList = null,
-                        partsList = listOf(collectionsPartsObjectMockManifestationA),
-                        workTypeList = collectionsWorkTypeListYearMock
+                    CollectionsNameObject(
+                        priRef = "123",
+                        name = "Schibsted",
+                        nameType = AxiellNameType.PUBLISHER.value,
+                        inputDate = "2020-01-01",
+                        inputTime = "12:00:00",
+                        inputName = "Bikube API",
+                        inputSource = "thesau>thesau"
                     )
                 )
             )
+        )
+        val collectionsTermModelMockLanguageA = CollectionsTermModel(
+            adlibJson = CollectionsTermRecordList(
+                recordList = listOf(
+                    CollectionsTermObject(
+                        priRef = "123",
+                        term = "nob",
+                        termType = AxiellTermType.LANGUAGE.value,
+                        inputDate = "2020-01-01",
+                        inputTime = "12:00:00",
+                        inputName = "Bikube API",
+                        inputSource = "thesau>thesau"
+                    )
+                )
+            )
+        )
+        val collectionsTermModelMockLocationB = CollectionsTermModel(
+            adlibJson = CollectionsTermRecordList(
+                recordList = listOf(
+                    CollectionsTermObject(
+                        priRef = "123",
+                        term = "Oslo",
+                        termType = AxiellTermType.LOCATION.value,
+                        inputDate = "2020-01-01",
+                        inputTime = "12:00:00",
+                        inputName = "Bikube API",
+                        inputSource = "thesaugeo>thesaugeo"
+                    )
+                )
+            )
+        )
+        val collectionsTermModelWithEmptyRecordListA = CollectionsTermModel(
+            adlibJson = CollectionsTermRecordList(recordList = null)
+        )
+        val collectionsNameModelWithEmptyRecordListA = CollectionsNameModel(
+            adlibJson = CollectionsNameRecordList(recordList = null)
         )
     }
 }

--- a/src/test/kotlin/no/nb/bikube/core/controller/CoreControllerTest.kt
+++ b/src/test/kotlin/no/nb/bikube/core/controller/CoreControllerTest.kt
@@ -1,16 +1,9 @@
 package no.nb.bikube.core.controller
 
 import com.ninjasquad.springmockk.MockkBean
-import io.mockk.Called
 import io.mockk.every
-import io.mockk.verify
 import no.nb.bikube.core.enum.MaterialType
-import no.nb.bikube.core.enum.SearchType
-import no.nb.bikube.core.exception.BadRequestBodyException
 import no.nb.bikube.core.exception.NotSupportedException
-import no.nb.bikube.core.model.Language
-import no.nb.bikube.core.model.Publisher
-import no.nb.bikube.core.model.PublisherPlace
 import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperItemMockA
 import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperTitleMockA
 import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperTitleMockB

--- a/src/test/kotlin/no/nb/bikube/core/controller/CoreControllerTest.kt
+++ b/src/test/kotlin/no/nb/bikube/core/controller/CoreControllerTest.kt
@@ -85,11 +85,11 @@ class CoreControllerTest {
 
     @Test
     fun `search title should return a list of titles matching name`() {
-        every { axiellService.getTitleByName(any()) } returns Flux.just(
+        every { axiellService.searchTitleByName(any()) } returns Flux.just(
             newspaperTitleMockA.copy(), newspaperTitleMockB.copy()
         )
 
-        coreController.getTitleByName("Avis", MaterialType.NEWSPAPER).body!!
+        coreController.search("Avis", MaterialType.NEWSPAPER).body!!
             .test()
             .expectSubscription()
             .assertNext {
@@ -103,16 +103,16 @@ class CoreControllerTest {
 
     @Test
     fun `search title should throw error when trying to get manuscripts`() {
-        assertThrows<NotSupportedException> { coreController.getTitleByName("Avis", MaterialType.MANUSCRIPT) }
+        assertThrows<NotSupportedException> { coreController.search("Avis", MaterialType.MANUSCRIPT) }
     }
 
     @Test
     fun `search title should throw error when trying to get periodicals`() {
-        assertThrows<NotSupportedException> { coreController.getTitleByName("Avis", MaterialType.PERIODICAL) }
+        assertThrows<NotSupportedException> { coreController.search("Avis", MaterialType.PERIODICAL) }
     }
 
     @Test
     fun `search title should throw error when trying to get monographs`() {
-        assertThrows<NotSupportedException> { coreController.getTitleByName("Avis", MaterialType.MONOGRAPH) }
+        assertThrows<NotSupportedException> { coreController.search("Avis", MaterialType.MONOGRAPH) }
     }
 }

--- a/src/test/kotlin/no/nb/bikube/core/controller/CoreControllerTest.kt
+++ b/src/test/kotlin/no/nb/bikube/core/controller/CoreControllerTest.kt
@@ -96,7 +96,7 @@ class CoreControllerTest {
             newspaperTitleMockA.copy(), newspaperTitleMockB.copy()
         )
 
-        coreController.search("Avis", SearchType.TITLE, MaterialType.NEWSPAPER).body!!
+        coreController.search("Avis", MaterialType.NEWSPAPER).body!!
             .test()
             .expectSubscription()
             .assertNext {
@@ -106,124 +106,5 @@ class CoreControllerTest {
                 Assertions.assertEquals(newspaperTitleMockB, it)
             }
             .verifyComplete()
-    }
-
-    @Test
-    fun `search should call correct service method when searchType is TITLE and materialType is NEWSPAPER`() {
-        every { axiellService.searchTitleByName(any()) } returns Flux.empty()
-        val searchTerm = "Hello world"
-        coreController.search(searchTerm, SearchType.TITLE, MaterialType.NEWSPAPER)
-        verify { axiellService.searchTitleByName(searchTerm) }
-    }
-
-    @Test
-    fun `search should call correct service method when searchType is PUBLISHER and materialType is NEWSPAPER`() {
-        every { axiellService.searchPublisherByName(any()) } returns Flux.empty()
-        val searchTerm = "Hello world"
-        coreController.search(searchTerm, SearchType.PUBLISHER, MaterialType.NEWSPAPER)
-        verify { axiellService.searchPublisherByName(searchTerm) }
-    }
-
-    @Test
-    fun `search should call correct service method when searchType is LANGUAGE and materialType is NEWSPAPER`() {
-        every { axiellService.searchLanguageByName(any()) } returns Flux.empty()
-        val searchTerm = "Hello world"
-        coreController.search(searchTerm, SearchType.LANGUAGE, MaterialType.NEWSPAPER)
-        verify { axiellService.searchLanguageByName(searchTerm) }
-    }
-
-    @Test
-    fun `search should call correct service method when searchType is LOCATION and materialType is NEWSPAPER`() {
-        every { axiellService.searchPublisherPlaceByName(any()) } returns Flux.empty()
-        val searchTerm = "Hello world"
-        coreController.search(searchTerm, SearchType.LOCATION, MaterialType.NEWSPAPER)
-        verify { axiellService.searchPublisherPlaceByName(searchTerm) }
-    }
-
-    @Test
-    fun `search should throw NotSupportedException when trying to get manuscripts`() {
-        assertThrows<NotSupportedException> { coreController.search("Avis", SearchType.TITLE, MaterialType.MANUSCRIPT) }
-    }
-
-    @Test
-    fun `search should throw NotSupportedException when trying to get periodicals`() {
-        assertThrows<NotSupportedException> { coreController.search("Avis", SearchType.TITLE, MaterialType.PERIODICAL) }
-    }
-
-    @Test
-    fun `search should throw NotSupportedException when trying to get monographs`() {
-        assertThrows<NotSupportedException> { coreController.search("Avis", SearchType.TITLE, MaterialType.MONOGRAPH) }
-    }
-
-    @Test
-    fun `search should throw BadRequestBodyException when search term is empty`() {
-        assertThrows<BadRequestBodyException> { coreController.search("", SearchType.TITLE, MaterialType.NEWSPAPER) }
-    }
-
-    @Test
-    fun `search should throw NotSupportedException when search type is item`() {
-        assertThrows<NotSupportedException> { coreController.search("Avis", SearchType.ITEM, MaterialType.NEWSPAPER) }
-    }
-
-    @Test
-    fun `createPublisher should return created publisher in body`() {
-        val publisher = Publisher("Amedia", "1")
-        every { axiellService.createPublisher(any()) } returns Mono.just(publisher)
-
-        coreController.createPublisher("Amedia")
-            .test()
-            .expectSubscription()
-            .assertNext {
-                Assertions.assertEquals(200, it.statusCode.value())
-                Assertions.assertEquals(publisher, it.body)
-            }
-            .verifyComplete()
-    }
-
-    @Test
-    fun `createPublisher should throw BadRequestBodyException if publisher name is empty`() {
-        assertThrows<BadRequestBodyException> { coreController.createPublisher("") }
-    }
-
-    @Test
-    fun `createPublisherPlace should return created publisher place in body`() {
-        val publisherPlace = PublisherPlace("Oslo", "1")
-        every { axiellService.createPublisherPlace(any()) } returns Mono.just(publisherPlace)
-
-        coreController.createPublisherPlace("Oslo")
-            .test()
-            .expectSubscription()
-            .assertNext {
-                Assertions.assertEquals(200, it.statusCode.value())
-                Assertions.assertEquals(publisherPlace, it.body)
-            }
-            .verifyComplete()
-    }
-
-    @Test
-    fun `createPublisherPlace should throw BadRequestBodyException if publisher place name is empty`() {
-        assertThrows<BadRequestBodyException> { coreController.createPublisherPlace("") }
-    }
-
-    @Test
-    fun `createLanguage should return created language in body`() {
-        val language = Language("eng", "1")
-        every { axiellService.createLanguage(any()) } returns Mono.just(language)
-
-        coreController.createLanguage("eng")
-            .test()
-            .expectSubscription()
-            .assertNext {
-                Assertions.assertEquals(200, it.statusCode.value())
-                Assertions.assertEquals(language, it.body)
-            }
-            .verifyComplete()
-    }
-
-    @Test
-    fun `createLanguage should throw BadRequestBodyException if language code is not in ISO-639-2 format`() {
-        assertThrows<BadRequestBodyException> { coreController.createLanguage("") }
-        assertThrows<BadRequestBodyException> { coreController.createLanguage("en") }
-        assertThrows<BadRequestBodyException> { coreController.createLanguage("english") }
     }
 }

--- a/src/test/kotlin/no/nb/bikube/core/controller/CoreControllerTest.kt
+++ b/src/test/kotlin/no/nb/bikube/core/controller/CoreControllerTest.kt
@@ -2,7 +2,10 @@ package no.nb.bikube.core.controller
 
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
+import io.mockk.verify
 import no.nb.bikube.core.enum.MaterialType
+import no.nb.bikube.core.enum.SearchType
+import no.nb.bikube.core.exception.BadRequestBodyException
 import no.nb.bikube.core.exception.NotSupportedException
 import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperItemMockA
 import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperTitleMockA
@@ -84,12 +87,12 @@ class CoreControllerTest {
     }
 
     @Test
-    fun `search title should return a list of titles matching name`() {
+    fun `search should return a list of titles matching name`() {
         every { axiellService.searchTitleByName(any()) } returns Flux.just(
             newspaperTitleMockA.copy(), newspaperTitleMockB.copy()
         )
 
-        coreController.search("Avis", MaterialType.NEWSPAPER).body!!
+        coreController.search("Avis", SearchType.TITLE, MaterialType.NEWSPAPER).body!!
             .test()
             .expectSubscription()
             .assertNext {
@@ -102,17 +105,59 @@ class CoreControllerTest {
     }
 
     @Test
-    fun `search title should throw error when trying to get manuscripts`() {
-        assertThrows<NotSupportedException> { coreController.search("Avis", MaterialType.MANUSCRIPT) }
+    fun `search should call correct service method when searchType is TITLE and materialType is NEWSPAPER`() {
+        every { axiellService.searchTitleByName(any()) } returns Flux.empty()
+        val searchTerm = "Hello world"
+        coreController.search(searchTerm, SearchType.TITLE, MaterialType.NEWSPAPER)
+        verify { axiellService.searchTitleByName(searchTerm) }
     }
 
     @Test
-    fun `search title should throw error when trying to get periodicals`() {
-        assertThrows<NotSupportedException> { coreController.search("Avis", MaterialType.PERIODICAL) }
+    fun `search should call correct service method when searchType is PUBLISHER and materialType is NEWSPAPER`() {
+        every { axiellService.searchPublisherByName(any()) } returns Flux.empty()
+        val searchTerm = "Hello world"
+        coreController.search(searchTerm, SearchType.PUBLISHER, MaterialType.NEWSPAPER)
+        verify { axiellService.searchPublisherByName(searchTerm) }
     }
 
     @Test
-    fun `search title should throw error when trying to get monographs`() {
-        assertThrows<NotSupportedException> { coreController.search("Avis", MaterialType.MONOGRAPH) }
+    fun `search should call correct service method when searchType is LANGUAGE and materialType is NEWSPAPER`() {
+        every { axiellService.searchLanguageByName(any()) } returns Flux.empty()
+        val searchTerm = "Hello world"
+        coreController.search(searchTerm, SearchType.LANGUAGE, MaterialType.NEWSPAPER)
+        verify { axiellService.searchLanguageByName(searchTerm) }
+    }
+
+    @Test
+    fun `search should call correct service method when searchType is LOCATION and materialType is NEWSPAPER`() {
+        every { axiellService.searchPublisherPlace(any()) } returns Flux.empty()
+        val searchTerm = "Hello world"
+        coreController.search(searchTerm, SearchType.LOCATION, MaterialType.NEWSPAPER)
+        verify { axiellService.searchPublisherPlace(searchTerm) }
+    }
+
+    @Test
+    fun `search should throw NotSupportedException when trying to get manuscripts`() {
+        assertThrows<NotSupportedException> { coreController.search("Avis", SearchType.TITLE, MaterialType.MANUSCRIPT) }
+    }
+
+    @Test
+    fun `search should throw NotSupportedException when trying to get periodicals`() {
+        assertThrows<NotSupportedException> { coreController.search("Avis", SearchType.TITLE, MaterialType.PERIODICAL) }
+    }
+
+    @Test
+    fun `search should throw NotSupportedException when trying to get monographs`() {
+        assertThrows<NotSupportedException> { coreController.search("Avis", SearchType.TITLE, MaterialType.MONOGRAPH) }
+    }
+
+    @Test
+    fun `search should throw BadRequestBodyException when search term is empty`() {
+        assertThrows<BadRequestBodyException> { coreController.search("", SearchType.TITLE, MaterialType.NEWSPAPER) }
+    }
+
+    @Test
+    fun `search should throw NotSupportedException when search type is item`() {
+        assertThrows<NotSupportedException> { coreController.search("Avis", SearchType.ITEM, MaterialType.NEWSPAPER) }
     }
 }

--- a/src/test/kotlin/no/nb/bikube/core/controller/CoreControllerTest.kt
+++ b/src/test/kotlin/no/nb/bikube/core/controller/CoreControllerTest.kt
@@ -1,7 +1,9 @@
 package no.nb.bikube.core.controller
 
 import com.ninjasquad.springmockk.MockkBean
+import io.mockk.Called
 import io.mockk.every
+import io.mockk.verify
 import no.nb.bikube.core.enum.MaterialType
 import no.nb.bikube.core.exception.NotSupportedException
 import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperItemMockA
@@ -99,5 +101,25 @@ class CoreControllerTest {
                 Assertions.assertEquals(newspaperTitleMockB, it)
             }
             .verifyComplete()
+    }
+
+    @Test
+    fun `search should throw NotSupportedException when trying to search for anything other than NEWSPAPER`() {
+        assertThrows<NotSupportedException> { coreController.search("Avis", MaterialType.MANUSCRIPT) }
+        assertThrows<NotSupportedException> { coreController.search("Avis", MaterialType.PERIODICAL) }
+        assertThrows<NotSupportedException> { coreController.search("Avis", MaterialType.MONOGRAPH) }
+
+        verify { axiellService.searchTitleByName(any()) wasNot Called }
+    }
+
+    @Test
+    fun `search should call on axiellService function when materialType is NEWSPAPER`() {
+        every { axiellService.searchTitleByName(any()) } returns Flux.empty()
+
+        coreController.search("Avis", MaterialType.NEWSPAPER).body!!
+            .test()
+            .verifyComplete()
+
+        verify { axiellService.searchTitleByName(any()) }
     }
 }

--- a/src/test/kotlin/no/nb/bikube/core/controller/CoreControllerTest.kt
+++ b/src/test/kotlin/no/nb/bikube/core/controller/CoreControllerTest.kt
@@ -1,6 +1,7 @@
 package no.nb.bikube.core.controller
 
 import com.ninjasquad.springmockk.MockkBean
+import io.mockk.Called
 import io.mockk.every
 import io.mockk.verify
 import no.nb.bikube.core.enum.MaterialType
@@ -130,10 +131,10 @@ class CoreControllerTest {
 
     @Test
     fun `search should call correct service method when searchType is LOCATION and materialType is NEWSPAPER`() {
-        every { axiellService.searchPublisherPlace(any()) } returns Flux.empty()
+        every { axiellService.searchPublisherPlaceByName(any()) } returns Flux.empty()
         val searchTerm = "Hello world"
         coreController.search(searchTerm, SearchType.LOCATION, MaterialType.NEWSPAPER)
-        verify { axiellService.searchPublisherPlace(searchTerm) }
+        verify { axiellService.searchPublisherPlaceByName(searchTerm) }
     }
 
     @Test
@@ -159,5 +160,20 @@ class CoreControllerTest {
     @Test
     fun `search should throw NotSupportedException when search type is item`() {
         assertThrows<NotSupportedException> { coreController.search("Avis", SearchType.ITEM, MaterialType.NEWSPAPER) }
+    }
+
+    @Test
+    fun `createLanguage should search for the given language code before attempting to create`() {
+        every { axiellService.searchLanguageByName(any()) } returns Flux.empty()
+        val languageCode = "eng"
+        coreController.createLanguage(languageCode)
+        verify { axiellService.searchLanguageByName(languageCode) }
+        verify { axiellService.createLanguage(languageCode) wasNot Called }
+    }
+
+    @Test
+    fun `createLanguage should throw BadRequestBodyException if language code is not in ISO-639-2 format`() {
+        assertThrows<BadRequestBodyException> { coreController.createLanguage("en") }
+        assertThrows<BadRequestBodyException> { coreController.createLanguage("english") }
     }
 }

--- a/src/test/kotlin/no/nb/bikube/core/controller/CoreControllerTest.kt
+++ b/src/test/kotlin/no/nb/bikube/core/controller/CoreControllerTest.kt
@@ -8,6 +8,9 @@ import no.nb.bikube.core.enum.MaterialType
 import no.nb.bikube.core.enum.SearchType
 import no.nb.bikube.core.exception.BadRequestBodyException
 import no.nb.bikube.core.exception.NotSupportedException
+import no.nb.bikube.core.model.Language
+import no.nb.bikube.core.model.Publisher
+import no.nb.bikube.core.model.PublisherPlace
 import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperItemMockA
 import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperTitleMockA
 import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperTitleMockB
@@ -163,16 +166,63 @@ class CoreControllerTest {
     }
 
     @Test
-    fun `createLanguage should search for the given language code before attempting to create`() {
-        every { axiellService.searchLanguageByName(any()) } returns Flux.empty()
-        val languageCode = "eng"
-        coreController.createLanguage(languageCode)
-        verify { axiellService.searchLanguageByName(languageCode) }
-        verify { axiellService.createLanguage(languageCode) wasNot Called }
+    fun `createPublisher should return created publisher in body`() {
+        val publisher = Publisher("Amedia", "1")
+        every { axiellService.createPublisher(any()) } returns Mono.just(publisher)
+
+        coreController.createPublisher("Amedia")
+            .test()
+            .expectSubscription()
+            .assertNext {
+                Assertions.assertEquals(200, it.statusCode.value())
+                Assertions.assertEquals(publisher, it.body)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `createPublisher should throw BadRequestBodyException if publisher name is empty`() {
+        assertThrows<BadRequestBodyException> { coreController.createPublisher("") }
+    }
+
+    @Test
+    fun `createPublisherPlace should return created publisher place in body`() {
+        val publisherPlace = PublisherPlace("Oslo", "1")
+        every { axiellService.createPublisherPlace(any()) } returns Mono.just(publisherPlace)
+
+        coreController.createPublisherPlace("Oslo")
+            .test()
+            .expectSubscription()
+            .assertNext {
+                Assertions.assertEquals(200, it.statusCode.value())
+                Assertions.assertEquals(publisherPlace, it.body)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `createPublisherPlace should throw BadRequestBodyException if publisher place name is empty`() {
+        assertThrows<BadRequestBodyException> { coreController.createPublisherPlace("") }
+    }
+
+    @Test
+    fun `createLanguage should return created language in body`() {
+        val language = Language("eng", "1")
+        every { axiellService.createLanguage(any()) } returns Mono.just(language)
+
+        coreController.createLanguage("eng")
+            .test()
+            .expectSubscription()
+            .assertNext {
+                Assertions.assertEquals(200, it.statusCode.value())
+                Assertions.assertEquals(language, it.body)
+            }
+            .verifyComplete()
     }
 
     @Test
     fun `createLanguage should throw BadRequestBodyException if language code is not in ISO-639-2 format`() {
+        assertThrows<BadRequestBodyException> { coreController.createLanguage("") }
         assertThrows<BadRequestBodyException> { coreController.createLanguage("en") }
         assertThrows<BadRequestBodyException> { coreController.createLanguage("english") }
     }

--- a/src/test/kotlin/no/nb/bikube/core/mapper/LanguageMapperTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/mapper/LanguageMapperTests.kt
@@ -1,0 +1,24 @@
+package no.nb.bikube.core.mapper
+
+import no.nb.bikube.core.CollectionsModelMockData.Companion.collectionsModelMockItemA
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest
+@ActiveProfiles("test")
+class LanguageMapperTests {
+
+    val languageMockA = collectionsModelMockItemA.adlibJson.recordList!!.first().copy(term = "nob", priRef = "123")
+
+    @Test
+    fun `Language mapper should map catalogueId`() {
+        Assertions.assertEquals("123", mapCollectionsObjectToGenericLanguage(languageMockA).catalogueId)
+    }
+
+    @Test
+    fun `Language mapper should map name`() {
+        Assertions.assertEquals("nob", mapCollectionsObjectToGenericLanguage(languageMockA).name)
+    }
+}

--- a/src/test/kotlin/no/nb/bikube/core/mapper/LanguageMapperTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/mapper/LanguageMapperTests.kt
@@ -1,6 +1,6 @@
 package no.nb.bikube.core.mapper
 
-import no.nb.bikube.core.CollectionsModelMockData.Companion.collectionsModelMockItemA
+import no.nb.bikube.core.CollectionsModelMockData.Companion.collectionsTermModelMockLanguageA
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
@@ -10,11 +10,11 @@ import org.springframework.test.context.ActiveProfiles
 @ActiveProfiles("test")
 class LanguageMapperTests {
 
-    val languageMockA = collectionsModelMockItemA.adlibJson.recordList!!.first().copy(term = "nob", priRef = "123")
+    val languageMockA = collectionsTermModelMockLanguageA.adlibJson.recordList!!.first()
 
     @Test
     fun `Language mapper should map catalogueId`() {
-        Assertions.assertEquals("123", mapCollectionsObjectToGenericLanguage(languageMockA).catalogueId)
+        Assertions.assertEquals("123", mapCollectionsObjectToGenericLanguage(languageMockA).databaseId)
     }
 
     @Test

--- a/src/test/kotlin/no/nb/bikube/core/mapper/PublisherMapperTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/mapper/PublisherMapperTests.kt
@@ -24,6 +24,6 @@ class PublisherMapperTests {
 
     @Test
     fun `Publisher mapper should map name`() {
-        Assertions.assertEquals("nob", mapCollectionsObjectToGenericLanguage(publisherPlaceMock).name)
+        Assertions.assertEquals("Schibsted", mapCollectionsObjectToGenericLanguage(publisherPlaceMock).name)
     }
 }

--- a/src/test/kotlin/no/nb/bikube/core/mapper/PublisherMapperTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/mapper/PublisherMapperTests.kt
@@ -1,6 +1,6 @@
 package no.nb.bikube.core.mapper
 
-import no.nb.bikube.core.CollectionsModelMockData
+import no.nb.bikube.core.CollectionsModelMockData.Companion.collectionsNameModelMockA
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
@@ -10,20 +10,15 @@ import org.springframework.test.context.ActiveProfiles
 @ActiveProfiles("test")
 class PublisherMapperTests {
 
-    val publisherPlaceMock = CollectionsModelMockData
-        .collectionsModelMockItemA
-        .adlibJson
-        .recordList!!
-        .first()
-        .copy(term = "Schibsted", priRef = "123")
+    val publisherPlaceMock = collectionsNameModelMockA.adlibJson.recordList!!.first()
 
     @Test
     fun `Publisher mapper should map catalogueId`() {
-        Assertions.assertEquals("123", mapCollectionsObjectToGenericLanguage(publisherPlaceMock).catalogueId)
+        Assertions.assertEquals("123", mapCollectionsObjectToGenericPublisher(publisherPlaceMock).databaseId)
     }
 
     @Test
     fun `Publisher mapper should map name`() {
-        Assertions.assertEquals("Schibsted", mapCollectionsObjectToGenericLanguage(publisherPlaceMock).name)
+        Assertions.assertEquals("Schibsted", mapCollectionsObjectToGenericPublisher(publisherPlaceMock).name)
     }
 }

--- a/src/test/kotlin/no/nb/bikube/core/mapper/PublisherMapperTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/mapper/PublisherMapperTests.kt
@@ -1,0 +1,29 @@
+package no.nb.bikube.core.mapper
+
+import no.nb.bikube.core.CollectionsModelMockData
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest
+@ActiveProfiles("test")
+class PublisherMapperTests {
+
+    val publisherPlaceMock = CollectionsModelMockData
+        .collectionsModelMockItemA
+        .adlibJson
+        .recordList!!
+        .first()
+        .copy(term = "Schibsted", priRef = "123")
+
+    @Test
+    fun `Publisher mapper should map catalogueId`() {
+        Assertions.assertEquals("123", mapCollectionsObjectToGenericLanguage(publisherPlaceMock).catalogueId)
+    }
+
+    @Test
+    fun `Publisher mapper should map name`() {
+        Assertions.assertEquals("nob", mapCollectionsObjectToGenericLanguage(publisherPlaceMock).name)
+    }
+}

--- a/src/test/kotlin/no/nb/bikube/core/mapper/PublisherPlaceMapperTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/mapper/PublisherPlaceMapperTests.kt
@@ -1,6 +1,6 @@
 package no.nb.bikube.core.mapper
 
-import no.nb.bikube.core.CollectionsModelMockData
+import no.nb.bikube.core.CollectionsModelMockData.Companion.collectionsTermModelMockLocationB
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
@@ -10,20 +10,18 @@ import org.springframework.test.context.ActiveProfiles
 @ActiveProfiles("test")
 class PublisherPlaceMapperTests {
 
-    val publisherPlaceMock = CollectionsModelMockData
-        .collectionsModelMockItemA
+    val publisherPlaceMock = collectionsTermModelMockLocationB
         .adlibJson
         .recordList!!
         .first()
-        .copy(term = "Oslo", priRef = "123")
 
     @Test
     fun `PublisherPlace mapper should map catalogueId`() {
-        Assertions.assertEquals("123", mapCollectionsObjectToGenericLanguage(publisherPlaceMock).catalogueId)
+        Assertions.assertEquals("123", mapCollectionsObjectToGenericPublisherPlace(publisherPlaceMock).databaseId)
     }
 
     @Test
     fun `PublisherPlace mapper should map name`() {
-        Assertions.assertEquals("Oslo", mapCollectionsObjectToGenericLanguage(publisherPlaceMock).name)
+        Assertions.assertEquals("Oslo", mapCollectionsObjectToGenericPublisherPlace(publisherPlaceMock).name)
     }
 }

--- a/src/test/kotlin/no/nb/bikube/core/mapper/PublisherPlaceMapperTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/mapper/PublisherPlaceMapperTests.kt
@@ -1,0 +1,29 @@
+package no.nb.bikube.core.mapper
+
+import no.nb.bikube.core.CollectionsModelMockData
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest
+@ActiveProfiles("test")
+class PublisherPlaceMapperTests {
+
+    val publisherPlaceMock = CollectionsModelMockData
+        .collectionsModelMockItemA
+        .adlibJson
+        .recordList!!
+        .first()
+        .copy(term = "Oslo", priRef = "123")
+
+    @Test
+    fun `PublisherPlace mapper should map catalogueId`() {
+        Assertions.assertEquals("123", mapCollectionsObjectToGenericLanguage(publisherPlaceMock).catalogueId)
+    }
+
+    @Test
+    fun `PublisherPlace mapper should map name`() {
+        Assertions.assertEquals("Oslo", mapCollectionsObjectToGenericLanguage(publisherPlaceMock).name)
+    }
+}

--- a/src/test/kotlin/no/nb/bikube/newspaper/NewspaperMockData.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/NewspaperMockData.kt
@@ -16,6 +16,7 @@ class NewspaperMockData {
             catalogueId = "1"
         )
 
+        // Equal to collectionsModelMockTitleE
         val newspaperTitleMockB = Title(
             name = "Avis B",
             startDate = LocalDate.parse("2020-01-01"),

--- a/src/test/kotlin/no/nb/bikube/newspaper/NewspaperMockData.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/NewspaperMockData.kt
@@ -51,7 +51,7 @@ class NewspaperMockData {
 
         val language: Language = Language(
             name = "nob",
-            catalogueId = "1"
+            databaseId = "1"
         )
     }
 }

--- a/src/test/kotlin/no/nb/bikube/newspaper/NewspaperMockData.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/NewspaperMockData.kt
@@ -47,5 +47,10 @@ class NewspaperMockData {
             titleName = newspaperTitleMockA.name,
             digital = true
         )
+
+        val language: Language = Language(
+            name = "nob",
+            catalogueId = "1"
+        )
     }
 }

--- a/src/test/kotlin/no/nb/bikube/newspaper/controller/TitleControllerTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/controller/TitleControllerTest.kt
@@ -1,55 +1,147 @@
-//package no.nb.bikube.newspaper.controller
-//
-//import com.ninjasquad.springmockk.MockkBean
-//import io.mockk.every
-//import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperTitleMockA
-//import no.nb.bikube.newspaper.service.AxiellService
-//import org.junit.jupiter.api.Assertions
-//import org.junit.jupiter.api.Test
-//import org.springframework.beans.factory.annotation.Autowired
-//import org.springframework.boot.test.context.SpringBootTest
-//import org.springframework.test.context.ActiveProfiles
-//import reactor.core.publisher.Flux.just
-//import reactor.kotlin.test.test
-//
-//@SpringBootTest
-//@ActiveProfiles("test")
-//class TitleControllerTest {
-//    @Autowired
-//    private lateinit var titleController: TitleController
-//
-//    @MockkBean
-//    private lateinit var axiellService: AxiellService
-//
-//    @Test
-//    fun `get titles should return 200 OK with list of titles`() {
-//        every { axiellService.getTitles() } returns just(newspaperTitleMockA.copy())
-//        titleController.getTitles().body!!.test()
-//            .expectSubscription()
-//            .assertNext {
-//                Assertions.assertEquals(newspaperTitleMockA, it)
-//            }
-//            .verifyComplete()
-//    }
-//
-//    @Test
-//    fun `create title should return 200 OK with the created title`() {
-//        every { axiellService.createTitle(newspaperTitleMockA) } returns just(newspaperTitleMockA.copy())
-//        titleController.createTitle(newspaperTitleMockA).body!!.test()
-//            .expectSubscription()
-//            .assertNext {
-//                Assertions.assertEquals(newspaperTitleMockA, it)
-//            }
-//            .verifyComplete()
-//    }
-//
-//    @Test
-//    fun `create title should return 400 bad request if request body object title is null or empty`() {
-//        Assertions.assertEquals(
-//            400, titleController.createTitle(newspaperTitleMockA.copy(name = null)).statusCode.value()
-//        )
-//        Assertions.assertEquals(
-//            400, titleController.createTitle(newspaperTitleMockA.copy(name = "")).statusCode.value()
-//        )
-//    }
-//}
+package no.nb.bikube.newspaper.controller
+
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.Called
+import io.mockk.every
+import io.mockk.verify
+import no.nb.bikube.core.exception.BadRequestBodyException
+import no.nb.bikube.core.model.Language
+import no.nb.bikube.core.model.Publisher
+import no.nb.bikube.core.model.PublisherPlace
+import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperTitleMockA
+import no.nb.bikube.newspaper.service.AxiellService
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.kotlin.test.test
+import java.time.LocalDate
+
+@SpringBootTest
+@ActiveProfiles("test")
+class TitleControllerTest {
+    @Autowired
+    private lateinit var titleController: TitleController
+
+    @MockkBean
+    private lateinit var axiellService: AxiellService
+
+    @Test
+    fun `getTitles should return 200 OK with list of titles`() {
+        every { axiellService.getTitles() } returns Flux.just(newspaperTitleMockA.copy())
+        titleController.getTitles().body!!
+            .test()
+            .expectSubscription()
+            .assertNext {
+                Assertions.assertEquals(newspaperTitleMockA, it)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `createTitle should return 200 OK with the created title`() {
+        every { axiellService.createPublisher(any()) } returns Mono.empty()
+        every { axiellService.createPublisherPlace(any()) } returns Mono.empty()
+        every { axiellService.createLanguage(any()) } returns Mono.empty()
+        every { axiellService.createTitle(any()) } returns Mono.just(newspaperTitleMockA.copy())
+
+        titleController.createTitle(newspaperTitleMockA)
+            .test()
+            .expectSubscription()
+            .assertNext {
+                Assertions.assertEquals(newspaperTitleMockA, it.body)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `createTitle should return 400 bad request if request body object title is null or empty`() {
+        titleController.createTitle(newspaperTitleMockA.copy(name = null))
+            .test()
+            .expectErrorMatches {
+                it is BadRequestBodyException &&
+                it.message == "Title name cannot be null or empty"
+            }
+            .verify()
+
+        titleController.createTitle(newspaperTitleMockA.copy(name = ""))
+            .test()
+            .expectErrorMatches {
+                it is BadRequestBodyException &&
+                it.message == "Title name cannot be null or empty"
+            }
+            .verify()
+    }
+
+    @Test
+    fun `createTitle should return BadRequestBodyException if startDate is after endDate`() {
+        val startDate = LocalDate.of(2020, 1, 1)
+        val endDate = LocalDate.of(2019, 1, 1)
+        titleController.createTitle(newspaperTitleMockA.copy(startDate = startDate, endDate = endDate))
+            .test()
+            .expectErrorMatches {
+                it is BadRequestBodyException &&
+                it.message == "Start date cannot be after end date"
+            }
+            .verify()
+    }
+
+    @Test
+    fun `createTitle should call create publisher if publisher is present on request body`() {
+        every { axiellService.createPublisher(any()) } returns Mono.just(Publisher("Pub", "1"))
+        every { axiellService.createTitle(any()) } returns Mono.just(newspaperTitleMockA.copy())
+        titleController.createTitle(newspaperTitleMockA.copy(publisher = "Pub", publisherPlace = null))
+            .test()
+            .expectSubscription()
+            .assertNext {
+                Assertions.assertEquals(newspaperTitleMockA, it.body)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `createTitle should call createPublisherPlace if publisherPlace is present on request body`() {
+        every { axiellService.createPublisherPlace(any()) } returns Mono.just(PublisherPlace("Pub", "1"))
+        every { axiellService.createTitle(any()) } returns Mono.just(newspaperTitleMockA.copy())
+        titleController.createTitle(newspaperTitleMockA.copy(publisherPlace = "Pub"))
+            .test()
+            .expectSubscription()
+            .assertNext {
+                Assertions.assertEquals(newspaperTitleMockA, it.body)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `createTitle should call createLanguage if language is present on request body`() {
+        every { axiellService.createLanguage(any()) } returns Mono.just(Language("nob", "1"))
+        every { axiellService.createTitle(any()) } returns Mono.just(newspaperTitleMockA.copy())
+        titleController.createTitle(newspaperTitleMockA.copy(language = "nob", publisherPlace = null))
+            .test()
+            .expectSubscription()
+            .assertNext {
+                Assertions.assertEquals(newspaperTitleMockA, it.body)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `createTitle should not call on createPublisher, createPublisherPlace or createLanguage if not present on request body`() {
+        val title = newspaperTitleMockA.copy(publisher = null, publisherPlace = null, language = null)
+        every { axiellService.createTitle(any()) } returns Mono.just(title)
+        titleController.createTitle(title)
+            .test()
+            .expectSubscription()
+            .assertNext {
+                Assertions.assertEquals(title, it.body)
+            }
+            .verifyComplete()
+
+        verify { axiellService.createPublisher(any()) wasNot Called }
+        verify { axiellService.createPublisherPlace(any()) wasNot Called }
+        verify { axiellService.createLanguage(any()) wasNot Called }
+    }
+}

--- a/src/test/kotlin/no/nb/bikube/newspaper/controller/TitleControllerTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/controller/TitleControllerTest.kt
@@ -1,55 +1,55 @@
-package no.nb.bikube.newspaper.controller
-
-import com.ninjasquad.springmockk.MockkBean
-import io.mockk.every
-import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperTitleMockA
-import no.nb.bikube.newspaper.service.AxiellService
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import reactor.core.publisher.Flux.just
-import reactor.kotlin.test.test
-
-@SpringBootTest
-@ActiveProfiles("test")
-class TitleControllerTest {
-    @Autowired
-    private lateinit var titleController: TitleController
-
-    @MockkBean
-    private lateinit var axiellService: AxiellService
-
-    @Test
-    fun `get titles should return 200 OK with list of titles`() {
-        every { axiellService.getTitles() } returns just(newspaperTitleMockA.copy())
-        titleController.getTitles().body!!.test()
-            .expectSubscription()
-            .assertNext {
-                Assertions.assertEquals(newspaperTitleMockA, it)
-            }
-            .verifyComplete()
-    }
-
-    @Test
-    fun `create title should return 200 OK with the created title`() {
-        every { axiellService.createTitle(newspaperTitleMockA) } returns just(newspaperTitleMockA.copy())
-        titleController.createTitle(newspaperTitleMockA).body!!.test()
-            .expectSubscription()
-            .assertNext {
-                Assertions.assertEquals(newspaperTitleMockA, it)
-            }
-            .verifyComplete()
-    }
-
-    @Test
-    fun `create title should return 400 bad request if request body object title is null or empty`() {
-        Assertions.assertEquals(
-            400, titleController.createTitle(newspaperTitleMockA.copy(name = null)).statusCode.value()
-        )
-        Assertions.assertEquals(
-            400, titleController.createTitle(newspaperTitleMockA.copy(name = "")).statusCode.value()
-        )
-    }
-}
+//package no.nb.bikube.newspaper.controller
+//
+//import com.ninjasquad.springmockk.MockkBean
+//import io.mockk.every
+//import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperTitleMockA
+//import no.nb.bikube.newspaper.service.AxiellService
+//import org.junit.jupiter.api.Assertions
+//import org.junit.jupiter.api.Test
+//import org.springframework.beans.factory.annotation.Autowired
+//import org.springframework.boot.test.context.SpringBootTest
+//import org.springframework.test.context.ActiveProfiles
+//import reactor.core.publisher.Flux.just
+//import reactor.kotlin.test.test
+//
+//@SpringBootTest
+//@ActiveProfiles("test")
+//class TitleControllerTest {
+//    @Autowired
+//    private lateinit var titleController: TitleController
+//
+//    @MockkBean
+//    private lateinit var axiellService: AxiellService
+//
+//    @Test
+//    fun `get titles should return 200 OK with list of titles`() {
+//        every { axiellService.getTitles() } returns just(newspaperTitleMockA.copy())
+//        titleController.getTitles().body!!.test()
+//            .expectSubscription()
+//            .assertNext {
+//                Assertions.assertEquals(newspaperTitleMockA, it)
+//            }
+//            .verifyComplete()
+//    }
+//
+//    @Test
+//    fun `create title should return 200 OK with the created title`() {
+//        every { axiellService.createTitle(newspaperTitleMockA) } returns just(newspaperTitleMockA.copy())
+//        titleController.createTitle(newspaperTitleMockA).body!!.test()
+//            .expectSubscription()
+//            .assertNext {
+//                Assertions.assertEquals(newspaperTitleMockA, it)
+//            }
+//            .verifyComplete()
+//    }
+//
+//    @Test
+//    fun `create title should return 400 bad request if request body object title is null or empty`() {
+//        Assertions.assertEquals(
+//            400, titleController.createTitle(newspaperTitleMockA.copy(name = null)).statusCode.value()
+//        )
+//        Assertions.assertEquals(
+//            400, titleController.createTitle(newspaperTitleMockA.copy(name = "")).statusCode.value()
+//        )
+//    }
+//}

--- a/src/test/kotlin/no/nb/bikube/newspaper/service/AxiellServiceTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/service/AxiellServiceTest.kt
@@ -73,6 +73,7 @@ class AxiellServiceTest(
                 language = newspaperTitleMockB.language,
                 recordType = AxiellRecordType.WORK.value,
                 descriptionType = AxiellDescriptionType.SERIAL.value,
+                medium = "Tekst",
                 subMedium = newspaperTitleMockB.materialType
             )
         )
@@ -412,6 +413,7 @@ class AxiellServiceTest(
                 language = newspaperTitleMockB.language,
                 recordType = AxiellRecordType.WORK.value,
                 descriptionType = AxiellDescriptionType.SERIAL.value,
+                medium = "Tekst",
                 subMedium = newspaperTitleMockB.materialType
             )
         )

--- a/src/test/kotlin/no/nb/bikube/newspaper/service/AxiellServiceTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/service/AxiellServiceTest.kt
@@ -18,10 +18,7 @@ import no.nb.bikube.core.CollectionsModelMockData.Companion.collectionsModelMock
 import no.nb.bikube.core.CollectionsModelMockData.Companion.collectionsPartOfObjectMockSerialWorkA
 import no.nb.bikube.core.enum.AxiellDescriptionType
 import no.nb.bikube.core.enum.AxiellRecordType
-import no.nb.bikube.core.exception.AxiellCollectionsException
-import no.nb.bikube.core.exception.AxiellTitleNotFound
-import no.nb.bikube.core.exception.GlobalControllerExceptionHandler
-import no.nb.bikube.core.exception.RecordAlreadyExistsException
+import no.nb.bikube.core.exception.*
 import no.nb.bikube.core.model.*
 import no.nb.bikube.core.model.dto.TitleDto
 import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperTitleMockA
@@ -29,6 +26,7 @@ import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperTitleMockB
 import no.nb.bikube.newspaper.repository.AxiellRepository
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
@@ -508,6 +506,11 @@ class AxiellServiceTest(
     }
 
     @Test
+    fun `createPublisher should throw BadRequestBodyException if publisher is empty`() {
+        assertThrows<BadRequestBodyException> { axiellService.createPublisher("") }
+    }
+
+    @Test
     fun `createPublisherPlace should return RecordAlreadyExistsException if searchPublisherPlace returns non-empty list`() {
         every { axiellRepository.searchPublisherPlace(any()) } returns Mono.just(collectionsModelMockTitleE)
         axiellService.createPublisherPlace("1")
@@ -531,12 +534,17 @@ class AxiellServiceTest(
     }
 
     @Test
+    fun `createPublisherPlace should throw BadRequestBodyException if publisher place is empty`() {
+        assertThrows<BadRequestBodyException> { axiellService.createPublisherPlace("") }
+    }
+
+    @Test
     fun `createLanguage should return RecordAlreadyExistsException if searchLanguage returns non-empty list`() {
         every { axiellRepository.searchLanguage(any()) } returns Mono.just(collectionsModelMockTitleE)
-        axiellService.createLanguage("1")
+        axiellService.createLanguage("nob")
             .test()
             .expectSubscription()
-            .expectErrorMatches { it is RecordAlreadyExistsException && it.message == "Language '1' already exists" }
+            .expectErrorMatches { it is RecordAlreadyExistsException && it.message == "Language 'nob' already exists" }
             .verify()
     }
 
@@ -545,11 +553,18 @@ class AxiellServiceTest(
         every { axiellRepository.searchLanguage(any()) } returns Mono.just(collectionsModelEmptyRecordListMock)
         every { axiellRepository.createRecord(any(), any()) } returns Mono.just(collectionsModelMockTitleE)
 
-        axiellService.createLanguage("2")
+        axiellService.createLanguage("nob")
             .test()
             .expectNext(Language(null, "2"))
             .verifyComplete()
 
         verify { axiellRepository.createRecord(any(), any()) }
+    }
+
+    @Test
+    fun `createLanguage should throw BadRequestBodyException if language code is not a valid ISO-639-2 language code`() {
+        assertThrows<BadRequestBodyException> { axiellService.createLanguage("") }
+        assertThrows<BadRequestBodyException> { axiellService.createLanguage("en") }
+        assertThrows<BadRequestBodyException> { axiellService.createLanguage("english") }
     }
 }

--- a/src/test/kotlin/no/nb/bikube/newspaper/service/AxiellServiceTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/service/AxiellServiceTest.kt
@@ -65,16 +65,16 @@ class AxiellServiceTest(
         val body = newspaperTitleMockB.copy()
         val encodedValue = Json.encodeToString(
             TitleDto(
-            title = newspaperTitleMockB.name!!,
-            dateStart = newspaperTitleMockB.startDate.toString(),
-            dateEnd = newspaperTitleMockB.endDate.toString(),
-            publisher = newspaperTitleMockB.publisher,
-            placeOfPublication = newspaperTitleMockB.publisherPlace,
-            language = newspaperTitleMockB.language,
-            recordType = AxiellRecordType.WORK.value,
-            descriptionType = AxiellDescriptionType.SERIAL.value,
-            subMedium = newspaperTitleMockB.materialType
-        )
+                title = newspaperTitleMockB.name!!,
+                dateStart = newspaperTitleMockB.startDate.toString(),
+                dateEnd = newspaperTitleMockB.endDate.toString(),
+                publisher = newspaperTitleMockB.publisher,
+                placeOfPublication = newspaperTitleMockB.publisherPlace,
+                language = newspaperTitleMockB.language,
+                recordType = AxiellRecordType.WORK.value,
+                descriptionType = AxiellDescriptionType.SERIAL.value,
+                subMedium = newspaperTitleMockB.materialType
+            )
         )
 
         axiellService.createTitle(body)

--- a/src/test/kotlin/no/nb/bikube/newspaper/service/AxiellServiceTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/service/AxiellServiceTest.kt
@@ -110,7 +110,7 @@ class AxiellServiceTest(
     fun `getItemsForTitle should return title information on items`() {
         every { axiellRepository.getSingleCollectionsModel(any()) } returns Mono.just(collectionsModelMockTitleA.copy())
 
-        val record: CollectionsObject = collectionsModelMockTitleA.adlibJson.recordList!!.first() as CollectionsObject
+        val record: CollectionsObject = collectionsModelMockTitleA.adlibJson.recordList!!.first()
         axiellService.getItemsForTitle(record.priRef)
             .test()
             .expectSubscription()

--- a/src/test/kotlin/no/nb/bikube/newspaper/service/AxiellServiceTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/service/AxiellServiceTest.kt
@@ -350,7 +350,7 @@ class AxiellServiceTest(
     fun `getTitleByName should return correctly mapped title`() {
         every { axiellRepository.getTitleByName(any()) } returns Mono.just(collectionsModelMockTitleA)
 
-        axiellService.getTitleByName("1")
+        axiellService.searchTitleByName("1")
             .test()
             .expectSubscription()
             .assertNext {

--- a/src/test/kotlin/no/nb/bikube/newspaper/service/AxiellServiceTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/service/AxiellServiceTest.kt
@@ -21,6 +21,7 @@ import no.nb.bikube.core.exception.AxiellCollectionsException
 import no.nb.bikube.core.exception.AxiellTitleNotFound
 import no.nb.bikube.core.exception.GlobalControllerExceptionHandler
 import no.nb.bikube.core.model.*
+import no.nb.bikube.core.model.dto.TitleDto
 import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperTitleMockB
 import no.nb.bikube.newspaper.repository.AxiellRepository
 import org.junit.jupiter.api.Assertions
@@ -55,10 +56,11 @@ class AxiellServiceTest(
 
     @Test
     fun `createTitle should return Title object with default values from Title with only name and materialType`() {
-        every { axiellRepository.createTitle(any()) } returns Mono.just(collectionsModelMockTitleE)
+        every { axiellRepository.createRecord(any()) } returns Mono.just(collectionsModelMockTitleE)
 
         val body = newspaperTitleMockB.copy()
-        val encodedValue = Json.encodeToString(TitleDto(
+        val encodedValue = Json.encodeToString(
+            TitleDto(
             title = newspaperTitleMockB.name!!,
             dateStart = newspaperTitleMockB.startDate.toString(),
             dateEnd = newspaperTitleMockB.endDate.toString(),
@@ -68,19 +70,20 @@ class AxiellServiceTest(
             recordType = AxiellRecordType.WORK.value,
             descriptionType = AxiellDescriptionType.SERIAL.value,
             subMedium = newspaperTitleMockB.materialType
-        ))
+        )
+        )
 
         axiellService.createTitle(body)
             .test()
             .expectNextMatches { it == newspaperTitleMockB }
             .verifyComplete()
 
-        verify { axiellRepository.createTitle(encodedValue) }
+        verify { axiellRepository.createRecord(encodedValue) }
     }
 
     @Test
     fun `createTitle should throw exception with error message from repository method`() {
-        every { axiellRepository.createTitle(any()) } returns Mono.error(AxiellCollectionsException("Error creating title"))
+        every { axiellRepository.createRecord(any()) } returns Mono.error(AxiellCollectionsException("Error creating title"))
 
         axiellService.createTitle(newspaperTitleMockB)
             .test()


### PR DESCRIPTION
Reformats the search function to work for more than just newspaper titles, can now also search for publisher, publisherPlace and language.
When creating a title, it will now check if the request body has publisher, publisher location and language, and if it does it will search for them in the catalogue and create records for them if they don't already exist.
Collection appears to automatically create them with a reference ID when using a publisher, location or language already registered in the catalogue.

Question for reviewer (@MariusLevang) Please look at the mappers for Publisher, PublisherPlace and Language (as well as the models). These are very similar. Should we combine them to general models/mappers or keep them as-is in there are more differences between each down the road?