### PR TITLE
feat: Create single newspaper items (TT-1097)

### DIFF
--- a/src/main/kotlin/no/nb/bikube/core/enum/MaterialType.kt
+++ b/src/main/kotlin/no/nb/bikube/core/enum/MaterialType.kt
@@ -1,8 +1,8 @@
 package no.nb.bikube.core.enum
 
-enum class MaterialType (val value: String) {
-    NEWSPAPER("Newspaper"),
-    MANUSCRIPT("Manuscript"),
-    PERIODICAL("Periodical"),
-    MONOGRAPH("Monograph")
+enum class MaterialType (val value: String, val norwegian: String) {
+    NEWSPAPER("Newspaper", "Avis"),
+    MANUSCRIPT("Manuscript", "Manuskript"),
+    PERIODICAL("Periodical", "Tidsskrift"),
+    MONOGRAPH("Monograph", "Monografi")
 }

--- a/src/main/kotlin/no/nb/bikube/core/exception/AxiellItemNotFound.kt
+++ b/src/main/kotlin/no/nb/bikube/core/exception/AxiellItemNotFound.kt
@@ -1,0 +1,3 @@
+package no.nb.bikube.core.exception
+
+class AxiellItemNotFound (message: String): AxiellCollectionsException(message)

--- a/src/main/kotlin/no/nb/bikube/core/exception/GlobalControllerExceptionHandler.kt
+++ b/src/main/kotlin/no/nb/bikube/core/exception/GlobalControllerExceptionHandler.kt
@@ -64,6 +64,17 @@ class GlobalControllerExceptionHandler {
 
         return problemDetail
     }
+
+    @ExceptionHandler(AxiellItemNotFound::class)
+    fun handleAxiellItemNotFoundException(exception: AxiellItemNotFound): ProblemDetail {
+        logger().warn("AxiellItemNotFound occurred: ${exception.message}")
+
+        val problemDetail = ProblemDetail.forStatus(HttpStatus.NOT_FOUND)
+        problemDetail.detail = "Collections item not found: ${exception.message}"
+        problemDetail.addDefaultProperties()
+
+        return problemDetail
+    }
 }
 
 fun ProblemDetail.addDefaultProperties() {

--- a/src/main/kotlin/no/nb/bikube/core/mapper/ItemMapper.kt
+++ b/src/main/kotlin/no/nb/bikube/core/mapper/ItemMapper.kt
@@ -1,9 +1,10 @@
 package no.nb.bikube.core.mapper
 
 import no.nb.bikube.core.enum.AxiellFormat
-import no.nb.bikube.core.model.CollectionsObject
-import no.nb.bikube.core.model.CollectionsPartsReference
+import no.nb.bikube.core.model.collections.CollectionsObject
+import no.nb.bikube.core.model.collections.CollectionsPartsReference
 import no.nb.bikube.core.model.Item
+import no.nb.bikube.core.model.collections.getUrn
 import no.nb.bikube.core.util.DateUtils.Companion.parseYearOrDate
 
 fun mapCollectionsObjectToGenericItem(model: CollectionsObject): Item {
@@ -14,7 +15,8 @@ fun mapCollectionsObjectToGenericItem(model: CollectionsObject): Item {
         materialType = model.partOfList?.first()?.partOfReference?.partOfGroup?.first()?.partOfReference?.partOfGroup?.first()?.partOfReference?.subMedium?.first()?.subMedium,
         titleCatalogueId = model.partOfList?.first()?.partOfReference?.partOfGroup?.first()?.partOfReference?.partOfGroup?.first()?.partOfReference?.priRef,
         titleName = model.partOfList?.first()?.partOfReference?.partOfGroup?.first()?.partOfReference?.partOfGroup?.first()?.partOfReference?.title?.first()?.title,
-        digital = model.formatList?.first()?.first { it.lang == "neutral" }?.text == AxiellFormat.DIGITAL.value
+        digital = model.formatList?.first()?.first { it.lang == "neutral" }?.text == AxiellFormat.DIGITAL.value,
+        urn = model.getUrn()
     )
 }
 
@@ -31,6 +33,7 @@ fun mapCollectionsPartsObjectToGenericItem(
         materialType = materialType,
         titleCatalogueId = titleCatalogueId,
         titleName = titleName,
-        digital = model.formatList?.first()?.first { it.lang == "neutral" }?.text == AxiellFormat.DIGITAL.value
+        digital = model.formatList?.first()?.first { it.lang == "neutral" }?.text == AxiellFormat.DIGITAL.value,
+        urn = null
     )
 }

--- a/src/main/kotlin/no/nb/bikube/core/mapper/LanguageMapper.kt
+++ b/src/main/kotlin/no/nb/bikube/core/mapper/LanguageMapper.kt
@@ -1,6 +1,6 @@
 package no.nb.bikube.core.mapper
 
-import no.nb.bikube.core.model.CollectionsTermObject
+import no.nb.bikube.core.model.collections.CollectionsTermObject
 import no.nb.bikube.core.model.Language
 
 fun mapCollectionsObjectToGenericLanguage(model: CollectionsTermObject): Language {

--- a/src/main/kotlin/no/nb/bikube/core/mapper/PublisherMapper.kt
+++ b/src/main/kotlin/no/nb/bikube/core/mapper/PublisherMapper.kt
@@ -1,6 +1,6 @@
 package no.nb.bikube.core.mapper
 
-import no.nb.bikube.core.model.CollectionsNameObject
+import no.nb.bikube.core.model.collections.CollectionsNameObject
 import no.nb.bikube.core.model.Publisher
 
 fun mapCollectionsObjectToGenericPublisher(model: CollectionsNameObject): Publisher {

--- a/src/main/kotlin/no/nb/bikube/core/mapper/PublisherPlaceMapper.kt
+++ b/src/main/kotlin/no/nb/bikube/core/mapper/PublisherPlaceMapper.kt
@@ -1,6 +1,6 @@
 package no.nb.bikube.core.mapper
 
-import no.nb.bikube.core.model.CollectionsTermObject
+import no.nb.bikube.core.model.collections.CollectionsTermObject
 import no.nb.bikube.core.model.PublisherPlace
 
 fun mapCollectionsObjectToGenericPublisherPlace(model: CollectionsTermObject): PublisherPlace {

--- a/src/main/kotlin/no/nb/bikube/core/mapper/TitleMapper.kt
+++ b/src/main/kotlin/no/nb/bikube/core/mapper/TitleMapper.kt
@@ -1,6 +1,6 @@
 package no.nb.bikube.core.mapper
 
-import no.nb.bikube.core.model.CollectionsObject
+import no.nb.bikube.core.model.collections.CollectionsObject
 import no.nb.bikube.core.model.Title
 import no.nb.bikube.core.util.DateUtils.Companion.parseYearOrDate
 

--- a/src/main/kotlin/no/nb/bikube/core/model/Item.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/Item.kt
@@ -3,11 +3,12 @@ package no.nb.bikube.core.model
 import java.time.LocalDate
 
 data class Item(
-    val catalogueId: String,
+    val catalogueId: String?,
     val name: String?,
     val date: LocalDate?,
     val materialType: String?,
     val titleCatalogueId: String?,
     val titleName: String?,
     val digital: Boolean?,
+    val urn: String?,
 )

--- a/src/main/kotlin/no/nb/bikube/core/model/collections/CollectionsNameObject.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/collections/CollectionsNameObject.kt
@@ -1,4 +1,4 @@
-package no.nb.bikube.core.model
+package no.nb.bikube.core.model.collections
 
 import com.fasterxml.jackson.annotation.JsonProperty
 

--- a/src/main/kotlin/no/nb/bikube/core/model/collections/CollectionsObject.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/collections/CollectionsObject.kt
@@ -1,7 +1,6 @@
-package no.nb.bikube.core.model
+package no.nb.bikube.core.model.collections
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import no.nb.bikube.core.enum.AxiellDescriptionType
 
 data class CollectionsModel(
     @JsonProperty("adlibJSON")
@@ -50,7 +49,10 @@ data class CollectionsObject(
     val partsList: List<CollectionsPartsObject>?,
 
     @JsonProperty("work.description_type")
-    val workTypeList: List<List<CollectionsLanguageListObject>>?
+    val workTypeList: List<List<CollectionsLanguageListObject>>?,
+
+    @JsonProperty("Alternative_number")
+    val alternativeNumberList: List<CollectionsAlternativeNumber>?
 )
 
 data class CollectionsTitle(
@@ -136,6 +138,11 @@ data class CollectionsPartsReference(
     val partsList: List<CollectionsPartsObject>?
 )
 
-fun CollectionsObject.isSerial(): Boolean {
-    return this.workTypeList?.first()?.first()?.text == AxiellDescriptionType.SERIAL.value
-}
+data class CollectionsAlternativeNumber(
+    @JsonProperty("alternative_number.type")
+    val type: String?,
+
+    @JsonProperty("alternative_number")
+    val value: String?
+)
+

--- a/src/main/kotlin/no/nb/bikube/core/model/collections/CollectionsObjectExtensions.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/collections/CollectionsObjectExtensions.kt
@@ -1,0 +1,11 @@
+package no.nb.bikube.core.model.collections
+
+import no.nb.bikube.core.enum.AxiellDescriptionType
+
+fun CollectionsObject.isSerial(): Boolean {
+    return this.workTypeList?.first()?.first()?.text == AxiellDescriptionType.SERIAL.value
+}
+
+fun CollectionsObject.getUrn(): String? {
+    return this.alternativeNumberList?.find { it.type == "URN" }?.value
+}

--- a/src/main/kotlin/no/nb/bikube/core/model/collections/CollectionsTermObject.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/collections/CollectionsTermObject.kt
@@ -1,4 +1,4 @@
-package no.nb.bikube.core.model
+package no.nb.bikube.core.model.collections
 
 import com.fasterxml.jackson.annotation.JsonProperty
 

--- a/src/main/kotlin/no/nb/bikube/core/model/dto/ItemDto.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/dto/ItemDto.kt
@@ -1,0 +1,35 @@
+package no.nb.bikube.core.model.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import no.nb.bikube.core.enum.AxiellFormat
+import no.nb.bikube.core.enum.AxiellRecordType
+import no.nb.bikube.core.model.Item
+
+@Serializable
+class ItemDto (
+    @SerialName("title")
+    val name: String?,
+
+    @SerialName("format")
+    val format: String,
+
+    @SerialName("record_type")
+    val recordType: String?,
+
+    @SerialName("alternative_number")
+    val altNumber: String?,
+
+    @SerialName("alternative_number.type")
+    val altNumberType: String?
+)
+
+fun createNewspaperItemDto(item: Item): ItemDto {
+    return ItemDto(
+        name = item.name,
+        format = if (item.digital == true) AxiellFormat.DIGITAL.value else AxiellFormat.PHYSICAL.value,
+        recordType = AxiellRecordType.ITEM.value,
+        altNumber = item.urn,
+        altNumberType = if (!item.urn.isNullOrBlank()) "URN" else null
+    )
+}

--- a/src/main/kotlin/no/nb/bikube/core/model/dto/TitleDto.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/dto/TitleDto.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import no.nb.bikube.core.enum.AxiellDescriptionType
 import no.nb.bikube.core.enum.AxiellRecordType
+import no.nb.bikube.core.enum.MaterialType
 import no.nb.bikube.core.model.Title
 
 @Serializable
@@ -49,6 +50,6 @@ fun createNewspaperTitleDto(title: Title): TitleDto {
         recordType = AxiellRecordType.WORK.value,
         descriptionType = AxiellDescriptionType.SERIAL.value,
         medium = "Tekst",
-        subMedium = "Avis"
+        subMedium = MaterialType.NEWSPAPER.norwegian
     )
 }

--- a/src/main/kotlin/no/nb/bikube/core/model/dto/TitleDto.kt
+++ b/src/main/kotlin/no/nb/bikube/core/model/dto/TitleDto.kt
@@ -49,6 +49,6 @@ fun createNewspaperTitleDto(title: Title): TitleDto {
         recordType = AxiellRecordType.WORK.value,
         descriptionType = AxiellDescriptionType.SERIAL.value,
         medium = "Tekst",
-        subMedium = title.materialType
+        subMedium = "Avis"
     )
 }

--- a/src/main/kotlin/no/nb/bikube/core/service/CreationValidationService.kt
+++ b/src/main/kotlin/no/nb/bikube/core/service/CreationValidationService.kt
@@ -1,0 +1,27 @@
+package no.nb.bikube.core.service
+
+import no.nb.bikube.core.exception.BadRequestBodyException
+import no.nb.bikube.core.model.Item
+import org.springframework.stereotype.Service
+
+@Service
+class CreationValidationService {
+    @Throws(BadRequestBodyException::class)
+    fun validateItem(item: Item) {
+        if (item.titleCatalogueId.isNullOrBlank()) {
+            throw BadRequestBodyException("Need to provide title ID")
+        }
+
+        if (item.date == null) {
+            throw BadRequestBodyException("Need to provide date")
+        }
+
+        if (item.digital == null) {
+            throw BadRequestBodyException("Need to provide if item is digital or not (physical)")
+        }
+
+        if (item.digital == true && item.urn.isNullOrBlank()) {
+            throw BadRequestBodyException("Need to provide URN for digital item")
+        }
+    }
+}

--- a/src/main/kotlin/no/nb/bikube/newspaper/controller/ItemController.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/controller/ItemController.kt
@@ -6,20 +6,19 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import no.nb.bikube.core.exception.AxiellCollectionsException
 import no.nb.bikube.core.model.Item
+import no.nb.bikube.core.service.CreationValidationService
 import no.nb.bikube.newspaper.service.AxiellService
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import reactor.core.publisher.Mono
 
 @RestController
 @Tag(name="Newspaper items", description="Endpoints related to newspaper items.")
 @RequestMapping("/newspapers/items")
 class ItemController (
-    private val axiellService: AxiellService
+    private val axiellService: AxiellService,
+    private val creationValidationService: CreationValidationService
 ){
     @GetMapping("/", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Get all newspaper items")
@@ -39,6 +38,24 @@ class ItemController (
 
         return results
             .collectList()
+            .map { ResponseEntity.ok(it) }
+    }
+
+    @PostMapping("/", produces = [MediaType.APPLICATION_JSON_VALUE])
+    @Operation(summary = "Create a single newspaper item")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "201", description = "Newspaper created"),
+        ApiResponse(responseCode = "400", description = "Bad request"),
+        ApiResponse(responseCode = "500", description = "Server error")
+    ])
+    fun createItem(
+        @RequestBody item: Item
+    ): Mono<ResponseEntity<Item>> {
+        creationValidationService.validateItem(item)
+
+        // Checks that title exists before creating item. Will throw exception if not found.
+        return axiellService.getSingleTitle(item.titleCatalogueId!!)
+            .flatMap { axiellService.createNewspaperItem(item) }
             .map { ResponseEntity.ok(it) }
     }
 }

--- a/src/main/kotlin/no/nb/bikube/newspaper/controller/TitleController.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/controller/TitleController.kt
@@ -73,7 +73,7 @@ class TitleController (
             } ?: Mono.empty()
 
             return Mono.`when`(publisherMono, locationMono, languageMono)
-                .then(axiellService.createTitle(title))
+                .then(axiellService.createNewspaperTitle(title))
                 .map { createdTitle -> ResponseEntity.ok(createdTitle) }
         }
     }

--- a/src/main/kotlin/no/nb/bikube/newspaper/repository/AxiellRepository.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/repository/AxiellRepository.kt
@@ -2,9 +2,9 @@ package no.nb.bikube.newspaper.repository
 
 import no.nb.bikube.core.enum.*
 import no.nb.bikube.core.exception.AxiellCollectionsException
-import no.nb.bikube.core.model.CollectionsModel
-import no.nb.bikube.core.model.CollectionsNameModel
-import no.nb.bikube.core.model.CollectionsTermModel
+import no.nb.bikube.core.model.collections.CollectionsModel
+import no.nb.bikube.core.model.collections.CollectionsNameModel
+import no.nb.bikube.core.model.collections.CollectionsTermModel
 import no.nb.bikube.core.util.logger
 import no.nb.bikube.newspaper.config.WebClientConfig
 import org.springframework.http.MediaType
@@ -61,7 +61,7 @@ class AxiellRepository(
     }
 
     @Throws(AxiellCollectionsException::class)
-    fun createRecord(serializedBody: String): Mono<CollectionsModel> {
+    fun createTextsRecord(serializedBody: String): Mono<CollectionsModel> {
         return createRecordWebClientRequest(serializedBody, AxiellDatabase.TEXTS).bodyToMono<CollectionsModel>()
     }
 

--- a/src/main/kotlin/no/nb/bikube/newspaper/service/AxiellService.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/service/AxiellService.kt
@@ -9,6 +9,9 @@ import no.nb.bikube.core.exception.BadRequestBodyException
 import no.nb.bikube.core.exception.RecordAlreadyExistsException
 import no.nb.bikube.core.mapper.*
 import no.nb.bikube.core.model.*
+import no.nb.bikube.core.model.collections.CollectionsModel
+import no.nb.bikube.core.model.collections.CollectionsObject
+import no.nb.bikube.core.model.collections.isSerial
 import no.nb.bikube.core.model.dto.*
 import no.nb.bikube.newspaper.repository.AxiellRepository
 import org.springframework.stereotype.Service
@@ -29,10 +32,10 @@ class AxiellService  (
     }
 
     @Throws(AxiellCollectionsException::class)
-    fun createTitle(title: Title): Mono<Title> {
+    fun createNewspaperTitle(title: Title): Mono<Title> {
         val dto: TitleDto = createNewspaperTitleDto(title)
         val encodedBody = Json.encodeToString(dto)
-        return axiellRepository.createRecord(encodedBody)
+        return axiellRepository.createTextsRecord(encodedBody)
             .handle { collectionsModel, sink: SynchronousSink<List<CollectionsObject>> ->
                 collectionsModel.adlibJson.recordList
                     ?. let { sink.next(collectionsModel.adlibJson.recordList) }

--- a/src/test/kotlin/no/nb/bikube/core/CollectionsModelMockData.kt
+++ b/src/test/kotlin/no/nb/bikube/core/CollectionsModelMockData.kt
@@ -1,7 +1,7 @@
 package no.nb.bikube.core
 
 import no.nb.bikube.core.enum.*
-import no.nb.bikube.core.model.*
+import no.nb.bikube.core.model.collections.*
 
 class CollectionsModelMockData {
     companion object {
@@ -137,7 +137,8 @@ class CollectionsModelMockData {
                         languageList = listOf(CollectionsLanguage(language = "nob")),
                         placeOfPublicationList = listOf("Mo I Rana"),
                         partsList = listOf(collectionsPartsObjectMockYearWorkA),
-                        workTypeList = collectionsWorkTypeListSerialMock
+                        workTypeList = collectionsWorkTypeListSerialMock,
+                        alternativeNumberList = null
                     )
                 )
             )
@@ -160,7 +161,8 @@ class CollectionsModelMockData {
                         languageList = listOf(CollectionsLanguage(language = "nob")),
                         placeOfPublicationList = listOf("Mo I Rana"),
                         partsList = null,
-                        workTypeList = collectionsWorkTypeListSerialMock
+                        workTypeList = collectionsWorkTypeListSerialMock,
+                        alternativeNumberList = null
                     )
                 )
             )
@@ -183,7 +185,8 @@ class CollectionsModelMockData {
                         languageList = listOf(CollectionsLanguage(language = "nob")),
                         placeOfPublicationList = listOf("Mo I Rana"),
                         partsList = listOf(collectionsPartsObjectMockYearWorkB),
-                        workTypeList = collectionsWorkTypeListSerialMock
+                        workTypeList = collectionsWorkTypeListSerialMock,
+                        alternativeNumberList = null
                     )
                 )
             )
@@ -206,7 +209,8 @@ class CollectionsModelMockData {
                         languageList = listOf(CollectionsLanguage(language = "nob")),
                         placeOfPublicationList = listOf("Mo I Rana"),
                         partsList = listOf(collectionsPartsObjectMockYearWorkC),
-                        workTypeList = collectionsWorkTypeListSerialMock
+                        workTypeList = collectionsWorkTypeListSerialMock,
+                        alternativeNumberList = null
                     )
                 )
             )
@@ -215,21 +219,24 @@ class CollectionsModelMockData {
         // Equal to newspaperTitleMockB
         val collectionsModelMockTitleE = CollectionsModel(
             adlibJson = CollectionsRecordList(
-                recordList = listOf(CollectionsObject(
-                    priRef = "2",
-                    titleList = listOf(CollectionsTitle("Avis B")),
-                    recordTypeList = listOf(listOf(CollectionsLanguageListObject("neutral", "WORK"))),
-                    formatList = null,
-                    partOfList = null,
-                    subMediumList = listOf(SubMedium("Avis")),
-                    mediumList = null,
-                    datingList = listOf(CollectionsDating("2020-01-01", "2020-01-31")),
-                    publisherList = listOf("B-Forlaget"),
-                    languageList = null,
-                    placeOfPublicationList = listOf("Brakka"),
-                    partsList = null,
-                    workTypeList = null
-                ))
+                recordList = listOf(
+                    CollectionsObject(
+                        priRef = "2",
+                        titleList = listOf(CollectionsTitle("Avis B")),
+                        recordTypeList = listOf(listOf(CollectionsLanguageListObject("neutral", "WORK"))),
+                        formatList = null,
+                        partOfList = null,
+                        subMediumList = listOf(SubMedium("Avis")),
+                        mediumList = null,
+                        datingList = listOf(CollectionsDating("2020-01-01", "2020-01-31")),
+                        publisherList = listOf("B-Forlaget"),
+                        languageList = null,
+                        placeOfPublicationList = listOf("Brakka"),
+                        partsList = null,
+                        workTypeList = null,
+                        alternativeNumberList = null
+                    )
+                )
             )
         )
 
@@ -288,7 +295,8 @@ class CollectionsModelMockData {
                         languageList = listOf(CollectionsLanguage(language = "nob")),
                         placeOfPublicationList = listOf("Mo I Rana"),
                         partsList = null,
-                        workTypeList = null
+                        workTypeList = null,
+                        alternativeNumberList = listOf(CollectionsAlternativeNumber("URN", "bikubeavisen_null_null_19991224_1_1_1"))
                     )
                 )
             )
@@ -310,7 +318,8 @@ class CollectionsModelMockData {
                         languageList = null,
                         placeOfPublicationList = null,
                         partsList = listOf(collectionsPartsObjectMockItemA),
-                        workTypeList = null
+                        workTypeList = null,
+                        alternativeNumberList = listOf(CollectionsAlternativeNumber("URN", "bikubeavisen_null_null_19991224_1_1_1"))
                     )
                 )
             )
@@ -331,7 +340,8 @@ class CollectionsModelMockData {
                         languageList = null,
                         placeOfPublicationList = null,
                         partsList = listOf(collectionsPartsObjectMockManifestationA),
-                        workTypeList = collectionsWorkTypeListYearMock
+                        workTypeList = collectionsWorkTypeListYearMock,
+                        alternativeNumberList = listOf(CollectionsAlternativeNumber("URN", "bikubeavisen_null_null_19991224_1_1_1"))
                     )
                 )
             )

--- a/src/test/kotlin/no/nb/bikube/core/CollectionsModelMockData.kt
+++ b/src/test/kotlin/no/nb/bikube/core/CollectionsModelMockData.kt
@@ -1,6 +1,8 @@
 package no.nb.bikube.core
 
-import no.nb.bikube.core.enum.*
+import no.nb.bikube.core.enum.AxiellDescriptionType
+import no.nb.bikube.core.enum.AxiellFormat
+import no.nb.bikube.core.enum.AxiellRecordType
 import no.nb.bikube.core.model.collections.*
 
 class CollectionsModelMockData {
@@ -297,6 +299,30 @@ class CollectionsModelMockData {
                         partsList = null,
                         workTypeList = null,
                         alternativeNumberList = listOf(CollectionsAlternativeNumber("URN", "bikubeavisen_null_null_19991224_1_1_1"))
+                    )
+                )
+            )
+        )
+
+        // Equals to newspaperItemMockB, except title mapping
+        val collectionsModelMockItemB = CollectionsModel(
+            adlibJson = CollectionsRecordList(
+                recordList = listOf(
+                    CollectionsObject(
+                        priRef = "46",
+                        titleList = listOf(CollectionsTitle(title = "Avis A 2020.01.05")),
+                        recordTypeList = collectionsRecordTypeListItemMock,
+                        formatList = collectionsFormatListDigitalMock,
+                        partOfList = null,
+                        subMediumList = null,
+                        mediumList = null,
+                        datingList = null,
+                        publisherList = null,
+                        languageList = null,
+                        placeOfPublicationList = null,
+                        partsList = null,
+                        workTypeList = null,
+                        alternativeNumberList = listOf(CollectionsAlternativeNumber("URN", "avisa_null_null_20200105_1_1_1"))
                     )
                 )
             )

--- a/src/test/kotlin/no/nb/bikube/core/CollectionsModelMockData.kt
+++ b/src/test/kotlin/no/nb/bikube/core/CollectionsModelMockData.kt
@@ -3,6 +3,7 @@ package no.nb.bikube.core
 import no.nb.bikube.core.enum.AxiellDescriptionType
 import no.nb.bikube.core.enum.AxiellFormat
 import no.nb.bikube.core.enum.AxiellRecordType
+import no.nb.bikube.core.enum.MaterialType
 import no.nb.bikube.core.model.collections.*
 
 class CollectionsModelMockData {
@@ -132,7 +133,7 @@ class CollectionsModelMockData {
                         recordTypeList = collectionsRecordTypeListWorkMock,
                         formatList = null,
                         partOfList = null,
-                        subMediumList = listOf(SubMedium(subMedium = "Avis")),
+                        subMediumList = listOf(SubMedium(subMedium = MaterialType.NEWSPAPER.norwegian)),
                         mediumList = listOf(Medium(medium = "Tekst")),
                         datingList = listOf(CollectionsDating(dateFrom = "2020-01-01", dateTo = null)),
                         publisherList = listOf("NB"),
@@ -156,7 +157,7 @@ class CollectionsModelMockData {
                         recordTypeList = collectionsRecordTypeListWorkMock,
                         formatList = null,
                         partOfList = null,
-                        subMediumList = listOf(SubMedium(subMedium = "Avis")),
+                        subMediumList = listOf(SubMedium(subMedium = MaterialType.NEWSPAPER.norwegian)),
                         mediumList = listOf(Medium(medium = "Tekst")),
                         datingList = listOf(CollectionsDating(dateFrom = "2000", dateTo = null)),
                         publisherList = listOf("NB"),
@@ -180,7 +181,7 @@ class CollectionsModelMockData {
                         recordTypeList = collectionsRecordTypeListWorkMock,
                         formatList = null,
                         partOfList = null,
-                        subMediumList = listOf(SubMedium(subMedium = "Avis")),
+                        subMediumList = listOf(SubMedium(subMedium = MaterialType.NEWSPAPER.norwegian)),
                         mediumList = listOf(Medium(medium = "Tekst")),
                         datingList = listOf(CollectionsDating(dateFrom = "2000", dateTo = null)),
                         publisherList = listOf("NB"),
@@ -204,7 +205,7 @@ class CollectionsModelMockData {
                         recordTypeList = collectionsRecordTypeListWorkMock,
                         formatList = null,
                         partOfList = null,
-                        subMediumList = listOf(SubMedium(subMedium = "Avis")),
+                        subMediumList = listOf(SubMedium(subMedium = MaterialType.NEWSPAPER.norwegian)),
                         mediumList = listOf(Medium(medium = "Tekst")),
                         datingList = listOf(CollectionsDating(dateFrom = "2000", dateTo = null)),
                         publisherList = listOf("NB"),
@@ -228,7 +229,7 @@ class CollectionsModelMockData {
                         recordTypeList = listOf(listOf(CollectionsLanguageListObject("neutral", "WORK"))),
                         formatList = null,
                         partOfList = null,
-                        subMediumList = listOf(SubMedium("Avis")),
+                        subMediumList = listOf(SubMedium(MaterialType.NEWSPAPER.norwegian)),
                         mediumList = null,
                         datingList = listOf(CollectionsDating("2020-01-01", "2020-01-31")),
                         publisherList = listOf("B-Forlaget"),
@@ -254,7 +255,7 @@ class CollectionsModelMockData {
                 partOfGroup = null,
                 title = listOf(CollectionsTitle(title = "Bikubeavisen")),
                 recordType = collectionsRecordTypeListWorkMock,
-                subMedium = listOf(SubMedium(subMedium = "Avis")),
+                subMedium = listOf(SubMedium(subMedium = MaterialType.NEWSPAPER.norwegian)),
                 workTypeList = collectionsWorkTypeListSerialMock
             )
         )

--- a/src/test/kotlin/no/nb/bikube/core/mapper/ItemMapperTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/mapper/ItemMapperTests.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import no.nb.bikube.core.model.CollectionsModel
+import no.nb.bikube.core.model.collections.CollectionsModel
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest

--- a/src/test/kotlin/no/nb/bikube/core/mapper/ItemMapperTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/mapper/ItemMapperTests.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import no.nb.bikube.core.enum.MaterialType
 import no.nb.bikube.core.model.collections.CollectionsModel
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -36,7 +37,7 @@ class ItemMapperTests {
     fun `Item mapper should map date`() { Assertions.assertEquals(LocalDate.parse("2012-01-02"), genericItem.date) }
 
     @Test
-    fun `Item mapper should map material type`() { Assertions.assertEquals("Avis", genericItem.materialType) }
+    fun `Item mapper should map material type`() { Assertions.assertEquals(MaterialType.NEWSPAPER.norwegian, genericItem.materialType) }
 
     @Test
     fun `Item mapper should map title ID`() { Assertions.assertEquals("3", genericItem.titleCatalogueId) }

--- a/src/test/kotlin/no/nb/bikube/core/mapper/ItemOnTitleMapperTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/mapper/ItemOnTitleMapperTests.kt
@@ -4,8 +4,9 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import no.nb.bikube.core.model.collections.CollectionsModel
+import no.nb.bikube.core.enum.MaterialType
 import no.nb.bikube.core.model.Item
+import no.nb.bikube.core.model.collections.CollectionsModel
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
@@ -77,7 +78,7 @@ class ItemOnTitleMapperTests {
     @Test
     fun `Item-on-title mapper should map material types`() {
         Assertions.assertTrue(mappedList.all {
-            it.materialType == "Avis"
+            it.materialType == MaterialType.NEWSPAPER.norwegian
         })
     }
 

--- a/src/test/kotlin/no/nb/bikube/core/mapper/ItemOnTitleMapperTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/mapper/ItemOnTitleMapperTests.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import no.nb.bikube.core.model.CollectionsModel
+import no.nb.bikube.core.model.collections.CollectionsModel
 import no.nb.bikube.core.model.Item
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/no/nb/bikube/core/mapper/TitleMapperTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/mapper/TitleMapperTests.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import no.nb.bikube.core.enum.MaterialType
 import no.nb.bikube.core.model.collections.CollectionsDating
 import no.nb.bikube.core.model.collections.CollectionsModel
 import org.junit.jupiter.api.Assertions
@@ -49,7 +50,7 @@ class TitleMapperTests {
 
     @Test
     fun `Title mapper should map material type`() {
-        Assertions.assertEquals("Avis", genericTitle.materialType)
+        Assertions.assertEquals(MaterialType.NEWSPAPER.norwegian, genericTitle.materialType)
     }
 
     @Test

--- a/src/test/kotlin/no/nb/bikube/core/mapper/TitleMapperTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/mapper/TitleMapperTests.kt
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import no.nb.bikube.core.model.CollectionsDating
-import no.nb.bikube.core.model.CollectionsModel
+import no.nb.bikube.core.model.collections.CollectionsDating
+import no.nb.bikube.core.model.collections.CollectionsModel
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest

--- a/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonListNewspaperItemsTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonListNewspaperItemsTests.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nb.bikube.core.enum.AxiellDescriptionType
 import no.nb.bikube.core.enum.AxiellFormat
 import no.nb.bikube.core.enum.AxiellRecordType
+import no.nb.bikube.core.enum.MaterialType
 import no.nb.bikube.core.model.collections.CollectionsModel
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -42,7 +43,7 @@ class CollectionsModelFromJsonListNewspaperItemsTests {
 
     @Test
     fun `Collection object should extract submediums`() {
-        Assertions.assertTrue(items.all { it.subMediumList!!.first().subMedium == "Avis" })
+        Assertions.assertTrue(items.all { it.subMediumList!!.first().subMedium == MaterialType.NEWSPAPER.norwegian })
     }
 
     @Test
@@ -72,7 +73,7 @@ class CollectionsModelFromJsonListNewspaperItemsTests {
         Assertions.assertEquals("10", mani1.priRef)
         Assertions.assertEquals("Bikubeavisen 2012.01.02", mani1.title!!.first().title)
         Assertions.assertEquals(AxiellRecordType.MANIFESTATION.value, mani1.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
-        Assertions.assertEquals("Avis", mani1.subMedium!!.first().subMedium)
+        Assertions.assertEquals(MaterialType.NEWSPAPER.norwegian, mani1.subMedium!!.first().subMedium)
 
         // Manifestation 1 and 2 should be the same
         val mani2 = items[1].partOfList!!.first().partOfReference!!
@@ -82,13 +83,13 @@ class CollectionsModelFromJsonListNewspaperItemsTests {
         Assertions.assertEquals("18", mani3.priRef)
         Assertions.assertEquals("Bikubeavisen 2011.01.24", mani3.title!!.first().title)
         Assertions.assertEquals(AxiellRecordType.MANIFESTATION.value, mani3.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
-        Assertions.assertEquals("Avis", mani3.subMedium!!.first().subMedium)
+        Assertions.assertEquals(MaterialType.NEWSPAPER.norwegian, mani3.subMedium!!.first().subMedium)
 
         val mani4 = items[3].partOfList!!.first().partOfReference!!
         Assertions.assertEquals("20", mani4.priRef)
         Assertions.assertEquals("Bikubeavisen 2012.01.09", mani4.title!!.first().title)
         Assertions.assertEquals(AxiellRecordType.MANIFESTATION.value, mani4.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
-        Assertions.assertEquals("Avis", mani4.subMedium!!.first().subMedium)
+        Assertions.assertEquals(MaterialType.NEWSPAPER.norwegian, mani4.subMedium!!.first().subMedium)
     }
 
     @Test
@@ -97,7 +98,7 @@ class CollectionsModelFromJsonListNewspaperItemsTests {
         Assertions.assertEquals("4", yearWork1.priRef)
         Assertions.assertEquals("Bikubeavisen 2012", yearWork1.title!!.first().title)
         Assertions.assertEquals(AxiellRecordType.WORK.value, yearWork1.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
-        Assertions.assertEquals("Avis", yearWork1.subMedium!!.first().subMedium)
+        Assertions.assertEquals(MaterialType.NEWSPAPER.norwegian, yearWork1.subMedium!!.first().subMedium)
         Assertions.assertEquals(AxiellDescriptionType.YEAR.value, yearWork1.workTypeList!!.first().first { langObj -> langObj.lang == "neutral" }.text)
 
         // Year work 1, 2 and 4 should be the same
@@ -108,7 +109,7 @@ class CollectionsModelFromJsonListNewspaperItemsTests {
         Assertions.assertEquals("11", yearWork3.priRef)
         Assertions.assertEquals("Bikubeavisen 2011", yearWork3.title!!.first().title)
         Assertions.assertEquals(AxiellRecordType.WORK.value, yearWork3.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
-        Assertions.assertEquals("Avis", yearWork3.subMedium!!.first().subMedium)
+        Assertions.assertEquals(MaterialType.NEWSPAPER.norwegian, yearWork3.subMedium!!.first().subMedium)
         Assertions.assertEquals(AxiellDescriptionType.YEAR.value, yearWork3.workTypeList!!.first().first { langObj -> langObj.lang == "neutral" }.text)
 
         val yearWork4 = items[3].partOfList!!.first().partOfReference!!.partOfGroup!!.first().partOfReference!!
@@ -122,7 +123,7 @@ class CollectionsModelFromJsonListNewspaperItemsTests {
         Assertions.assertEquals("3", title1.priRef)
         Assertions.assertEquals("Bikubeavisen", title1.title!!.first().title)
         Assertions.assertEquals(AxiellRecordType.WORK.value, title1.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
-        Assertions.assertEquals("Avis", title1.subMedium!!.first().subMedium)
+        Assertions.assertEquals(MaterialType.NEWSPAPER.norwegian, title1.subMedium!!.first().subMedium)
         Assertions.assertEquals(AxiellDescriptionType.SERIAL.value, title1.workTypeList!!.first().first { langObj -> langObj.lang == "neutral" }.text)
 
         val title2 = items[1].partOfList!!.first().partOfReference!!.partOfGroup!!.first().partOfReference!!.partOfGroup!!.first().partOfReference!!

--- a/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonListNewspaperItemsTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonListNewspaperItemsTests.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nb.bikube.core.enum.AxiellDescriptionType
 import no.nb.bikube.core.enum.AxiellFormat
 import no.nb.bikube.core.enum.AxiellRecordType
+import no.nb.bikube.core.model.collections.CollectionsModel
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest

--- a/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonListNewspaperTitlesTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonListNewspaperTitlesTests.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import no.nb.bikube.core.model.collections.CollectionsModel
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest

--- a/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonListNewspaperTitlesTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonListNewspaperTitlesTests.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import no.nb.bikube.core.enum.MaterialType
 import no.nb.bikube.core.model.collections.CollectionsModel
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -38,7 +39,7 @@ class CollectionsModelFromJsonListNewspaperTitlesTests {
 
     @Test
     fun `Title object should extract submediums`() {
-        Assertions.assertTrue(titles.all { it.subMediumList!!.first().subMedium == "Avis" })
+        Assertions.assertTrue(titles.all { it.subMediumList!!.first().subMedium == MaterialType.NEWSPAPER.norwegian })
     }
 
     @Test

--- a/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonSingleNewspaperItemTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonSingleNewspaperItemTests.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nb.bikube.core.enum.AxiellDescriptionType
 import no.nb.bikube.core.enum.AxiellFormat
 import no.nb.bikube.core.enum.AxiellRecordType
+import no.nb.bikube.core.enum.MaterialType
 import no.nb.bikube.core.model.collections.CollectionsModel
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -49,7 +50,7 @@ class CollectionsModelFromJsonSingleNewspaperItemTests {
     @Test
     fun `Item object should extract submedium`() {
         Assertions.assertEquals(
-            "Avis",
+            MaterialType.NEWSPAPER.norwegian,
             singleItem.subMediumList!!.first().subMedium
         )
     }
@@ -75,7 +76,7 @@ class CollectionsModelFromJsonSingleNewspaperItemTests {
         val manifestation = singleItem.partOfList!!.first().partOfReference!!
         Assertions.assertEquals("10", manifestation.priRef)
         Assertions.assertEquals("Bikubeavisen 2012.01.02", manifestation.title!!.first().title)
-        Assertions.assertEquals("Avis", manifestation.subMedium!!.first().subMedium)
+        Assertions.assertEquals(MaterialType.NEWSPAPER.norwegian, manifestation.subMedium!!.first().subMedium)
         Assertions.assertEquals(
             AxiellRecordType.MANIFESTATION.value,
             manifestation.recordType!!.first().first { langObj -> langObj.lang == "neutral"}.text
@@ -88,7 +89,7 @@ class CollectionsModelFromJsonSingleNewspaperItemTests {
         Assertions.assertEquals("4", yearWork.priRef)
         Assertions.assertEquals("Bikubeavisen 2012", yearWork.title!!.first().title)
         Assertions.assertEquals(AxiellRecordType.WORK.value, yearWork.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
-        Assertions.assertEquals("Avis", yearWork.subMedium!!.first().subMedium)
+        Assertions.assertEquals(MaterialType.NEWSPAPER.norwegian, yearWork.subMedium!!.first().subMedium)
         Assertions.assertEquals(AxiellDescriptionType.YEAR.value, yearWork.workTypeList!!.first().first { langObj -> langObj.lang == "neutral" }.text)
     }
 
@@ -98,7 +99,7 @@ class CollectionsModelFromJsonSingleNewspaperItemTests {
         Assertions.assertEquals("3", title.priRef)
         Assertions.assertEquals("Bikubeavisen", title.title!!.first().title)
         Assertions.assertEquals(AxiellRecordType.WORK.value, title.recordType!!.first().first { langObj -> langObj.lang == "neutral" }.text)
-        Assertions.assertEquals("Avis", title.subMedium!!.first().subMedium)
+        Assertions.assertEquals(MaterialType.NEWSPAPER.norwegian, title.subMedium!!.first().subMedium)
         Assertions.assertEquals(AxiellDescriptionType.SERIAL.value, title.workTypeList!!.first().first { langObj -> langObj.lang == "neutral" }.text)
     }
 

--- a/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonSingleNewspaperItemTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonSingleNewspaperItemTests.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nb.bikube.core.enum.AxiellDescriptionType
 import no.nb.bikube.core.enum.AxiellFormat
 import no.nb.bikube.core.enum.AxiellRecordType
+import no.nb.bikube.core.model.collections.CollectionsModel
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest

--- a/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonSingleNewspaperTitleTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonSingleNewspaperTitleTests.kt
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nb.bikube.core.enum.AxiellDescriptionType
 import no.nb.bikube.core.enum.AxiellFormat
 import no.nb.bikube.core.enum.AxiellRecordType
+import no.nb.bikube.core.model.collections.CollectionsModel
+import no.nb.bikube.core.model.collections.CollectionsPartsObject
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest

--- a/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonSingleNewspaperTitleTests.kt
+++ b/src/test/kotlin/no/nb/bikube/core/model/CollectionsModelFromJsonSingleNewspaperTitleTests.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nb.bikube.core.enum.AxiellDescriptionType
 import no.nb.bikube.core.enum.AxiellFormat
 import no.nb.bikube.core.enum.AxiellRecordType
+import no.nb.bikube.core.enum.MaterialType
 import no.nb.bikube.core.model.collections.CollectionsModel
 import no.nb.bikube.core.model.collections.CollectionsPartsObject
 import org.junit.jupiter.api.Assertions
@@ -41,7 +42,10 @@ class CollectionsModelFromJsonSingleNewspaperTitleTests {
     fun `Title object should extract language`() { Assertions.assertEquals("nob", singleTitle.languageList!!.first().language) }
 
     @Test
-    fun `Title object should extract submedium`() { Assertions.assertEquals("Avis", singleTitle.subMediumList!!.first().subMedium) }
+    fun `Title object should extract submedium`() {
+        Assertions.assertEquals(MaterialType.NEWSPAPER.norwegian,
+        singleTitle.subMediumList!!.first().subMedium)
+    }
 
     @Test
     fun `Title object should extract title`() { Assertions.assertEquals("Bikubeavisen", singleTitle.titleList!!.first().title) }

--- a/src/test/kotlin/no/nb/bikube/core/service/CreationValidationServiceTest.kt
+++ b/src/test/kotlin/no/nb/bikube/core/service/CreationValidationServiceTest.kt
@@ -1,0 +1,68 @@
+package no.nb.bikube.core.service
+
+import no.nb.bikube.core.exception.BadRequestBodyException
+import no.nb.bikube.core.model.Item
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.time.LocalDate
+
+@SpringBootTest
+@ActiveProfiles("test")
+class CreationValidationServiceTest {
+    @Autowired
+    private lateinit var creationValidationService: CreationValidationService
+
+    private val validDigitalItem = Item(
+        catalogueId = null,
+        name = "Test",
+        date = LocalDate.parse("2020-01-01"),
+        materialType = null,
+        titleCatalogueId = "1",
+        titleName = null,
+        digital = true,
+        urn = "avis_null_null_20200101_1_1_1"
+    )
+
+    private val validPhysicalItem = Item(
+        catalogueId = null,
+        name = "Test",
+        date = LocalDate.parse("2020-01-01"),
+        materialType = null,
+        titleCatalogueId = "1",
+        titleName = null,
+        digital = false,
+        urn = null
+    )
+
+    @Test
+    fun `validateItem should allow valid items`() {
+        Assertions.assertDoesNotThrow{ creationValidationService.validateItem(validDigitalItem) }
+        Assertions.assertDoesNotThrow{ creationValidationService.validateItem(validPhysicalItem) }
+    }
+
+    @Test
+    fun `validateItem should throw exception if titleCatalogueId is null or blank`() {
+        assertThrows<BadRequestBodyException> { creationValidationService.validateItem(validPhysicalItem.copy(titleCatalogueId = null)) }
+        assertThrows<BadRequestBodyException> { creationValidationService.validateItem(validDigitalItem.copy(titleCatalogueId = "")) }
+    }
+
+    @Test
+    fun `validateItem should throw exception if date is null`() {
+        assertThrows<BadRequestBodyException> { creationValidationService.validateItem(validPhysicalItem.copy(date = null)) }
+    }
+
+    @Test
+    fun `validateItem should throw exception if digital is null`() {
+        assertThrows<BadRequestBodyException> { creationValidationService.validateItem(validPhysicalItem.copy(digital = null)) }
+    }
+
+    @Test
+    fun `validateItem should throw exception if digital is true and urn is null or blank`() {
+        assertThrows<BadRequestBodyException> { creationValidationService.validateItem(validDigitalItem.copy(urn = null)) }
+        assertThrows<BadRequestBodyException> { creationValidationService.validateItem(validDigitalItem.copy(urn = "")) }
+    }
+}

--- a/src/test/kotlin/no/nb/bikube/newspaper/NewspaperMockData.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/NewspaperMockData.kt
@@ -1,5 +1,6 @@
 package no.nb.bikube.newspaper
 
+import no.nb.bikube.core.enum.MaterialType
 import no.nb.bikube.core.model.Item
 import no.nb.bikube.core.model.Language
 import no.nb.bikube.core.model.Title
@@ -26,7 +27,7 @@ class NewspaperMockData {
             publisher = "B-Forlaget",
             publisherPlace = "Brakka",
             language = null,
-            materialType = "Avis",
+            materialType = MaterialType.NEWSPAPER.norwegian,
             catalogueId = "2"
         )
 
@@ -37,7 +38,7 @@ class NewspaperMockData {
             publisher = null,
             publisherPlace = null,
             language = null,
-            materialType = "Avis",
+            materialType = MaterialType.NEWSPAPER.norwegian,
             catalogueId = "3"
         )
 
@@ -45,7 +46,7 @@ class NewspaperMockData {
             catalogueId = "2",
             name = "Avis A 2020.01.01",
             date = null,
-            materialType = "Avis",
+            materialType = MaterialType.NEWSPAPER.norwegian,
             titleCatalogueId = newspaperTitleMockA.catalogueId,
             titleName = newspaperTitleMockA.name,
             digital = true,

--- a/src/test/kotlin/no/nb/bikube/newspaper/NewspaperMockData.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/NewspaperMockData.kt
@@ -1,6 +1,8 @@
 package no.nb.bikube.newspaper
 
-import no.nb.bikube.core.model.*
+import no.nb.bikube.core.model.Item
+import no.nb.bikube.core.model.Language
+import no.nb.bikube.core.model.Title
 import java.time.LocalDate
 
 class NewspaperMockData {
@@ -48,6 +50,18 @@ class NewspaperMockData {
             titleName = newspaperTitleMockA.name,
             digital = true,
             urn = "avisa_null_null_20200101_1_1_1"
+        )
+
+       // Equals to collectionsModelMockItemB - used for creation
+        val newspaperItemMockB = Item(
+            catalogueId = "46",
+            name = "Avis A 2020.01.05",
+            date = LocalDate.parse("2020-01-05"),
+            materialType = null,
+            titleCatalogueId = newspaperTitleMockA.catalogueId,
+            titleName = null,
+            digital = true,
+            urn = "avisa_null_null_20200105_1_1_1"
         )
 
         val language: Language = Language(

--- a/src/test/kotlin/no/nb/bikube/newspaper/NewspaperMockData.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/NewspaperMockData.kt
@@ -46,7 +46,8 @@ class NewspaperMockData {
             materialType = "Avis",
             titleCatalogueId = newspaperTitleMockA.catalogueId,
             titleName = newspaperTitleMockA.name,
-            digital = true
+            digital = true,
+            urn = "avisa_null_null_20200101_1_1_1"
         )
 
         val language: Language = Language(

--- a/src/test/kotlin/no/nb/bikube/newspaper/controller/ItemControllerTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/controller/ItemControllerTest.kt
@@ -2,7 +2,9 @@ package no.nb.bikube.newspaper.controller
 
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
+import no.nb.bikube.core.service.CreationValidationService
 import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperItemMockA
+import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperTitleMockA
 import no.nb.bikube.newspaper.service.AxiellService
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -10,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 import reactor.kotlin.test.test
 
 @SpringBootTest
@@ -21,6 +24,9 @@ class ItemControllerTest {
     @MockkBean
     private lateinit var axiellService: AxiellService
 
+    @MockkBean
+    private lateinit var creationValidationService: CreationValidationService
+
     @Test
     fun `get items should return 200 OK with list of items`() {
         every { axiellService.getAllItems() } returns Flux.just(newspaperItemMockA.copy())
@@ -28,6 +34,24 @@ class ItemControllerTest {
             .expectSubscription()
             .assertNext {
                 Assertions.assertEquals(listOf(newspaperItemMockA), it.body)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `create item should return 200 OK with created item`() {
+        every { axiellService.getSingleTitle(any()) } returns Mono.just(newspaperTitleMockA.copy())
+        every { axiellService.createNewspaperItem(any()) } returns Mono.just(newspaperItemMockA.copy())
+        every { creationValidationService.validateItem(any()) } returns Unit
+
+        itemController.createItem(newspaperItemMockA.copy())
+            .test()
+            .expectSubscription()
+            .assertNext {
+                Assertions.assertEquals(
+                    newspaperItemMockA.copy(),
+                    it.body
+                )
             }
             .verifyComplete()
     }

--- a/src/test/kotlin/no/nb/bikube/newspaper/controller/TitleControllerTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/controller/TitleControllerTest.kt
@@ -47,7 +47,7 @@ class TitleControllerTest {
         every { axiellService.createPublisher(any()) } returns Mono.empty()
         every { axiellService.createPublisherPlace(any()) } returns Mono.empty()
         every { axiellService.createLanguage(any()) } returns Mono.empty()
-        every { axiellService.createTitle(any()) } returns Mono.just(newspaperTitleMockA.copy())
+        every { axiellService.createNewspaperTitle(any()) } returns Mono.just(newspaperTitleMockA.copy())
 
         titleController.createTitle(newspaperTitleMockA)
             .test()
@@ -93,7 +93,7 @@ class TitleControllerTest {
     @Test
     fun `createTitle should call create publisher if publisher is present on request body`() {
         every { axiellService.createPublisher(any()) } returns Mono.just(Publisher("Pub", "1"))
-        every { axiellService.createTitle(any()) } returns Mono.just(newspaperTitleMockA.copy())
+        every { axiellService.createNewspaperTitle(any()) } returns Mono.just(newspaperTitleMockA.copy())
         titleController.createTitle(newspaperTitleMockA.copy(publisher = "Pub", publisherPlace = null))
             .test()
             .expectSubscription()
@@ -106,7 +106,7 @@ class TitleControllerTest {
     @Test
     fun `createTitle should call createPublisherPlace if publisherPlace is present on request body`() {
         every { axiellService.createPublisherPlace(any()) } returns Mono.just(PublisherPlace("Pub", "1"))
-        every { axiellService.createTitle(any()) } returns Mono.just(newspaperTitleMockA.copy())
+        every { axiellService.createNewspaperTitle(any()) } returns Mono.just(newspaperTitleMockA.copy())
         titleController.createTitle(newspaperTitleMockA.copy(publisherPlace = "Pub"))
             .test()
             .expectSubscription()
@@ -119,7 +119,7 @@ class TitleControllerTest {
     @Test
     fun `createTitle should call createLanguage if language is present on request body`() {
         every { axiellService.createLanguage(any()) } returns Mono.just(Language("nob", "1"))
-        every { axiellService.createTitle(any()) } returns Mono.just(newspaperTitleMockA.copy())
+        every { axiellService.createNewspaperTitle(any()) } returns Mono.just(newspaperTitleMockA.copy())
         titleController.createTitle(newspaperTitleMockA.copy(language = "nob", publisherPlace = null))
             .test()
             .expectSubscription()
@@ -132,7 +132,7 @@ class TitleControllerTest {
     @Test
     fun `createTitle should not call on createPublisher, createPublisherPlace or createLanguage if not present on request body`() {
         val title = newspaperTitleMockA.copy(publisher = null, publisherPlace = null, language = null)
-        every { axiellService.createTitle(any()) } returns Mono.just(title)
+        every { axiellService.createNewspaperTitle(any()) } returns Mono.just(title)
         titleController.createTitle(title)
             .test()
             .expectSubscription()
@@ -153,7 +153,7 @@ class TitleControllerTest {
         )
         every { axiellService.createPublisherPlace(any()) } returns Mono.just(PublisherPlace("Oslo", "1"))
         every { axiellService.createLanguage(any()) } returns Mono.just(Language("nob", "1"))
-        every { axiellService.createTitle(any()) } returns Mono.just(newspaperTitleMockA.copy())
+        every { axiellService.createNewspaperTitle(any()) } returns Mono.just(newspaperTitleMockA.copy())
         titleController.createTitle(newspaperTitleMockA.copy(publisher = "Schibsted"))
             .test()
             .expectSubscription()
@@ -170,7 +170,7 @@ class TitleControllerTest {
             RecordAlreadyExistsException("Publisher place 'Oslo' already exists")
         )
         every { axiellService.createLanguage(any()) } returns Mono.just(Language("nob", "1"))
-        every { axiellService.createTitle(any()) } returns Mono.just(newspaperTitleMockA.copy())
+        every { axiellService.createNewspaperTitle(any()) } returns Mono.just(newspaperTitleMockA.copy())
         titleController.createTitle(newspaperTitleMockA.copy(publisherPlace = "Oslo"))
             .test()
             .expectSubscription()
@@ -187,7 +187,7 @@ class TitleControllerTest {
         every { axiellService.createLanguage(any()) } returns Mono.error(
             RecordAlreadyExistsException("Language 'nob' already exists")
         )
-        every { axiellService.createTitle(any()) } returns Mono.just(newspaperTitleMockA.copy())
+        every { axiellService.createNewspaperTitle(any()) } returns Mono.just(newspaperTitleMockA.copy())
         titleController.createTitle(newspaperTitleMockA.copy(language = "nob"))
             .test()
             .expectSubscription()

--- a/src/test/kotlin/no/nb/bikube/newspaper/service/AxiellServiceTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/service/AxiellServiceTest.kt
@@ -24,6 +24,10 @@ import no.nb.bikube.core.enum.AxiellDescriptionType
 import no.nb.bikube.core.enum.AxiellRecordType
 import no.nb.bikube.core.exception.*
 import no.nb.bikube.core.model.*
+import no.nb.bikube.core.model.collections.CollectionsModel
+import no.nb.bikube.core.model.collections.CollectionsObject
+import no.nb.bikube.core.model.collections.CollectionsRecordList
+import no.nb.bikube.core.model.collections.getUrn
 import no.nb.bikube.core.model.dto.TitleDto
 import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperTitleMockB
 import no.nb.bikube.newspaper.repository.AxiellRepository
@@ -60,7 +64,7 @@ class AxiellServiceTest(
 
     @Test
     fun `createTitle should return Title object with default values from Title with only name and materialType`() {
-        every { axiellRepository.createRecord(any()) } returns Mono.just(collectionsModelMockTitleE)
+        every { axiellRepository.createTextsRecord(any()) } returns Mono.just(collectionsModelMockTitleE)
 
         val body = newspaperTitleMockB.copy()
         val encodedValue = Json.encodeToString(
@@ -78,19 +82,19 @@ class AxiellServiceTest(
             )
         )
 
-        axiellService.createTitle(body)
+        axiellService.createNewspaperTitle(body)
             .test()
             .expectNextMatches { it == newspaperTitleMockB }
             .verifyComplete()
 
-        verify { axiellRepository.createRecord(encodedValue) }
+        verify { axiellRepository.createTextsRecord(encodedValue) }
     }
 
     @Test
     fun `createTitle should throw exception with error message from repository method`() {
-        every { axiellRepository.createRecord(any()) } returns Mono.error(AxiellCollectionsException("Error creating title"))
+        every { axiellRepository.createTextsRecord(any()) } returns Mono.error(AxiellCollectionsException("Error creating title"))
 
-        axiellService.createTitle(newspaperTitleMockB)
+        axiellService.createNewspaperTitle(newspaperTitleMockB)
             .test()
             .expectErrorMatches { it is AxiellCollectionsException && it.message == "Error creating title" }
             .verify()
@@ -207,7 +211,8 @@ class AxiellServiceTest(
                         materialType = testSerialWork.subMedium!!.first().subMedium,
                         titleCatalogueId = testSerialWork.priRef,
                         titleName = testSerialWork.title!!.first().title,
-                        digital = true
+                        digital = true,
+                        urn = testRecord.getUrn()
                     ),
                     it
                 )
@@ -392,8 +397,8 @@ class AxiellServiceTest(
 
     @Test
     fun `createTitle should return correctly mapped record`() {
-        every { axiellRepository.createRecord(any()) } returns Mono.just(collectionsModelMockTitleE)
-        axiellService.createTitle(newspaperTitleMockB.copy())
+        every { axiellRepository.createTextsRecord(any()) } returns Mono.just(collectionsModelMockTitleE)
+        axiellService.createNewspaperTitle(newspaperTitleMockB.copy())
             .test()
             .expectSubscription()
             .assertNext { Assertions.assertEquals(newspaperTitleMockB, it) }
@@ -402,7 +407,7 @@ class AxiellServiceTest(
 
     @Test
     fun `createTitle should correctly encode the title object sent to json string`() {
-        every { axiellRepository.createRecord(any()) } returns Mono.just(collectionsModelMockTitleE)
+        every { axiellRepository.createTextsRecord(any()) } returns Mono.just(collectionsModelMockTitleE)
         val encodedValue = Json.encodeToString(
             TitleDto(
                 title = newspaperTitleMockB.name!!,
@@ -418,13 +423,13 @@ class AxiellServiceTest(
             )
         )
 
-        axiellService.createTitle(newspaperTitleMockB.copy())
+        axiellService.createNewspaperTitle(newspaperTitleMockB.copy())
             .test()
             .expectSubscription()
             .assertNext { Assertions.assertEquals(newspaperTitleMockB, it) }
             .verifyComplete()
 
-        verify { axiellRepository.createRecord(encodedValue) }
+        verify { axiellRepository.createTextsRecord(encodedValue) }
     }
 
     @Test

--- a/src/test/kotlin/no/nb/bikube/newspaper/service/AxiellServiceTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/service/AxiellServiceTest.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import no.nb.bikube.core.CollectionsModelMockData.Companion.collectionsModelEmptyRecordListMock
 import no.nb.bikube.core.CollectionsModelMockData.Companion.collectionsModelMockItemA
+import no.nb.bikube.core.CollectionsModelMockData.Companion.collectionsModelMockItemB
 import no.nb.bikube.core.CollectionsModelMockData.Companion.collectionsModelMockManifestationA
 import no.nb.bikube.core.CollectionsModelMockData.Companion.collectionsModelMockTitleA
 import no.nb.bikube.core.CollectionsModelMockData.Companion.collectionsModelMockTitleB
@@ -21,6 +22,7 @@ import no.nb.bikube.core.CollectionsModelMockData.Companion.collectionsTermModel
 import no.nb.bikube.core.CollectionsModelMockData.Companion.collectionsTermModelMockLocationB
 import no.nb.bikube.core.CollectionsModelMockData.Companion.collectionsTermModelWithEmptyRecordListA
 import no.nb.bikube.core.enum.AxiellDescriptionType
+import no.nb.bikube.core.enum.AxiellFormat
 import no.nb.bikube.core.enum.AxiellRecordType
 import no.nb.bikube.core.exception.*
 import no.nb.bikube.core.model.*
@@ -28,7 +30,9 @@ import no.nb.bikube.core.model.collections.CollectionsModel
 import no.nb.bikube.core.model.collections.CollectionsObject
 import no.nb.bikube.core.model.collections.CollectionsRecordList
 import no.nb.bikube.core.model.collections.getUrn
+import no.nb.bikube.core.model.dto.ItemDto
 import no.nb.bikube.core.model.dto.TitleDto
+import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperItemMockB
 import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperTitleMockB
 import no.nb.bikube.newspaper.repository.AxiellRepository
 import org.junit.jupiter.api.Assertions
@@ -543,5 +547,53 @@ class AxiellServiceTest(
         assertThrows<BadRequestBodyException> { axiellService.createLanguage("") }
         assertThrows<BadRequestBodyException> { axiellService.createLanguage("en") }
         assertThrows<BadRequestBodyException> { axiellService.createLanguage("english") }
+    }
+
+    @Test
+    fun `createNewspaperItem should return correctly mapped item record`() {
+        every { axiellRepository.createTextsRecord(any()) } returns Mono.just(collectionsModelMockItemB)
+
+        axiellService.createNewspaperItem(newspaperItemMockB.copy(catalogueId = null))
+            .test()
+            .expectSubscription()
+            .assertNext { Assertions.assertEquals(newspaperItemMockB.copy(titleCatalogueId = null), it) }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `createNewspaperItem should correctly encode the item object sent to json string`() {
+        every { axiellRepository.createTextsRecord(any()) } returns Mono.just(collectionsModelMockItemB)
+
+        val encodedValue = Json.encodeToString(
+            ItemDto(
+                name = newspaperItemMockB.name!!,
+                format = AxiellFormat.DIGITAL.value,
+                recordType = AxiellRecordType.ITEM.value,
+                altNumber = newspaperItemMockB.urn,
+                altNumberType = "URN"
+            )
+        )
+
+        axiellService.createNewspaperItem(newspaperItemMockB.copy(catalogueId = null))
+            .test()
+            .expectSubscription()
+            .assertNext { Assertions.assertEquals(newspaperItemMockB.copy(titleCatalogueId = null), it) }
+            .verifyComplete()
+
+        verify { axiellRepository.createTextsRecord(encodedValue) }
+    }
+
+    @Test
+    fun `createNewspaperItem should throw AxiellItemNotFound if item could not be found`() {
+        every { axiellRepository.createTextsRecord(any()) } returns Mono.just(collectionsModelEmptyRecordListMock)
+
+        axiellService.createNewspaperItem(newspaperItemMockB.copy(catalogueId = null))
+            .test()
+            .expectSubscription()
+            .expectErrorMatches {
+                it is AxiellItemNotFound &&
+                it.message!!.contains("New item not found")
+            }
+            .verify()
     }
 }


### PR DESCRIPTION
Added endpoint and functionality for creating newspaper items
Changed some method names to specify we are talking aboth newspapers
Added URN for digital items (both get and post)
Moved collection models to separate folder to avoid messy structure