### PR TITLE
fix: make all tests work in random order (TT-1221)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>3.2.1</version>
 				<configuration>
-					<runOrder>alphabetical</runOrder>
+					<runOrder>random</runOrder>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/test/kotlin/no/nb/bikube/newspaper/controller/ItemControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/controller/ItemControllerIntegrationTest.kt
@@ -2,6 +2,7 @@ package no.nb.bikube.newspaper.controller
 
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
+import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.verify
 import kotlinx.serialization.json.Json
@@ -37,6 +38,7 @@ import reactor.core.publisher.Mono
 import reactor.kotlin.test.test
 import java.time.Duration
 import java.time.LocalDate
+import java.time.LocalTime
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
@@ -88,6 +90,9 @@ class ItemControllerIntegrationTest (
                 else -> Mono.just(collectionsModelEmptyRecordListMock)
             }
         }
+
+        mockkStatic(LocalTime::class)
+        every { LocalTime.now() } returns LocalTime.of(9, 30, 0)
     }
 
     @Test

--- a/src/test/kotlin/no/nb/bikube/newspaper/controller/ItemControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/controller/ItemControllerIntegrationTest.kt
@@ -2,7 +2,6 @@ package no.nb.bikube.newspaper.controller
 
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
-import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.verify
 import kotlinx.serialization.json.Json
@@ -38,7 +37,6 @@ import reactor.core.publisher.Mono
 import reactor.kotlin.test.test
 import java.time.Duration
 import java.time.LocalDate
-import java.time.LocalTime
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
@@ -90,9 +88,6 @@ class ItemControllerIntegrationTest (
                 else -> Mono.just(collectionsModelEmptyRecordListMock)
             }
         }
-
-        mockkStatic(LocalTime::class)
-        every { LocalTime.now() } returns LocalTime.of(9, 30, 0)
     }
 
     @Test

--- a/src/test/kotlin/no/nb/bikube/newspaper/service/AxiellServiceTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/service/AxiellServiceTest.kt
@@ -2,6 +2,8 @@ package no.nb.bikube.newspaper.service
 
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -36,9 +38,7 @@ import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperItemMockB
 import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperTitleInputDtoMockB
 import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperTitleMockB
 import no.nb.bikube.newspaper.repository.AxiellRepository
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
@@ -53,11 +53,28 @@ import java.time.format.DateTimeFormatter
 class AxiellServiceTest(
     @Autowired private val globalControllerExceptionHandler: GlobalControllerExceptionHandler
 ) {
+
+    companion object {
+        @JvmStatic
+        @AfterAll
+        fun unmockLocalTime() {
+            unmockkStatic(LocalTime::class)
+        }
+    }
+
     @Autowired
     private lateinit var axiellService: AxiellService
 
     @MockkBean
     private lateinit var axiellRepository: AxiellRepository
+
+    private val mockedTime = LocalTime.of(9, 30, 0)
+
+    @BeforeEach
+    fun mockLocalTime() {
+        mockkStatic(LocalTime::class)
+        every { LocalTime.now() } returns mockedTime
+    }
 
     private val yearWorkEncodedDto = Json.encodeToString(YearDto(
         partOfReference = newspaperItemMockB.titleCatalogueId,
@@ -68,7 +85,7 @@ class AxiellServiceTest(
         inputName = "Bikube API",
         inputSource = "texts>texts",
         inputDate = LocalDate.now().toString(),
-        inputTime = LocalTime.now().format(DateTimeFormatter.ofPattern("HH:mm:ss")).toString(),
+        inputTime = mockedTime.format(DateTimeFormatter.ofPattern("HH:mm:ss")).toString(),
         dataset = "texts"
     ))
 
@@ -79,7 +96,7 @@ class AxiellServiceTest(
         inputName = "Bikube API",
         inputSource = "texts>texts",
         inputDate = LocalDate.now().toString(),
-        inputTime = LocalTime.now().format(DateTimeFormatter.ofPattern("HH:mm:ss")).toString(),
+        inputTime = mockedTime.format(DateTimeFormatter.ofPattern("HH:mm:ss")).toString(),
         dataset = "texts"
     ))
 
@@ -91,7 +108,7 @@ class AxiellServiceTest(
         inputName = "Bikube API",
         inputSource = "texts>texts",
         inputDate = LocalDate.now().toString(),
-        inputTime = LocalTime.now().format(DateTimeFormatter.ofPattern("HH:mm:ss")).toString(),
+        inputTime = mockedTime.format(DateTimeFormatter.ofPattern("HH:mm:ss")).toString(),
         dataset = "texts",
         partOfReference = newspaperItemMockB.catalogueId
     ))
@@ -104,9 +121,27 @@ class AxiellServiceTest(
         inputName = "Bikube API",
         inputSource = "texts>texts",
         inputDate = LocalDate.now().toString(),
-        inputTime = LocalTime.now().format(DateTimeFormatter.ofPattern("HH:mm:ss")).toString(),
+        inputTime = mockedTime.format(DateTimeFormatter.ofPattern("HH:mm:ss")).toString(),
         dataset = "texts",
         partOfReference = newspaperItemMockB.catalogueId)
+    )
+
+    private val titleEncodedDto = Json.encodeToString(TitleDto(
+        title = newspaperTitleMockB.name!!,
+        dateStart = newspaperTitleMockB.startDate.toString(),
+        dateEnd = newspaperTitleMockB.endDate.toString(),
+        publisher = newspaperTitleMockB.publisher,
+        placeOfPublication = newspaperTitleMockB.publisherPlace,
+        language = newspaperTitleMockB.language,
+        recordType = AxiellRecordType.WORK.value,
+        descriptionType = AxiellDescriptionType.SERIAL.value,
+        medium = "Tekst",
+        subMedium = newspaperTitleMockB.materialType,
+        inputName = "Bikube API",
+        inputSource = "texts>texts",
+        inputDate = LocalDate.now().toString(),
+        inputTime = mockedTime.format(DateTimeFormatter.ofPattern("HH:mm:ss")).toString(),
+        dataset = "texts")
     )
 
     @Test
@@ -114,32 +149,13 @@ class AxiellServiceTest(
         every { axiellRepository.createTextsRecord(any()) } returns Mono.just(collectionsModelMockTitleE)
 
         val body = newspaperTitleInputDtoMockB.copy()
-        val encodedValue = Json.encodeToString(
-            TitleDto(
-                title = newspaperTitleMockB.name!!,
-                dateStart = newspaperTitleMockB.startDate.toString(),
-                dateEnd = newspaperTitleMockB.endDate.toString(),
-                publisher = newspaperTitleMockB.publisher,
-                placeOfPublication = newspaperTitleMockB.publisherPlace,
-                language = newspaperTitleMockB.language,
-                recordType = AxiellRecordType.WORK.value,
-                descriptionType = AxiellDescriptionType.SERIAL.value,
-                medium = "Tekst",
-                subMedium = newspaperTitleMockB.materialType,
-                inputName = "Bikube API",
-                inputSource = "texts>texts",
-                inputDate = LocalDate.now().toString(),
-                inputTime = LocalTime.now().format(DateTimeFormatter.ofPattern("HH:mm:ss")).toString(),
-                dataset = "texts"
-            )
-        )
 
         axiellService.createNewspaperTitle(body)
             .test()
             .expectNextMatches { it == newspaperTitleMockB }
             .verifyComplete()
 
-        verify { axiellRepository.createTextsRecord(encodedValue) }
+        verify { axiellRepository.createTextsRecord(titleEncodedDto) }
     }
 
     @Test
@@ -460,25 +476,6 @@ class AxiellServiceTest(
     @Test
     fun `createTitle should correctly encode the title object sent to json string`() {
         every { axiellRepository.createTextsRecord(any()) } returns Mono.just(collectionsModelMockTitleE)
-        val encodedValue = Json.encodeToString(
-            TitleDto(
-                title = newspaperTitleMockB.name!!,
-                dateStart = newspaperTitleMockB.startDate.toString(),
-                dateEnd = newspaperTitleMockB.endDate.toString(),
-                publisher = newspaperTitleMockB.publisher,
-                placeOfPublication = newspaperTitleMockB.publisherPlace,
-                language = newspaperTitleMockB.language,
-                recordType = AxiellRecordType.WORK.value,
-                descriptionType = AxiellDescriptionType.SERIAL.value,
-                medium = "Tekst",
-                subMedium = newspaperTitleMockB.materialType,
-                inputName = "Bikube API",
-                inputSource = "texts>texts",
-                inputDate = LocalDate.now().toString(),
-                inputTime = LocalTime.now().format(DateTimeFormatter.ofPattern("HH:mm:ss")).toString(),
-                dataset = "texts"
-            )
-        )
 
         axiellService.createNewspaperTitle(newspaperTitleInputDtoMockB.copy())
             .test()
@@ -486,7 +483,7 @@ class AxiellServiceTest(
             .assertNext { Assertions.assertEquals(newspaperTitleMockB, it) }
             .verifyComplete()
 
-        verify { axiellRepository.createTextsRecord(encodedValue) }
+        verify { axiellRepository.createTextsRecord(titleEncodedDto) }
     }
 
     @Test

--- a/src/test/kotlin/no/nb/bikube/newspaper/service/AxiellServiceTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/service/AxiellServiceTest.kt
@@ -2,7 +2,6 @@ package no.nb.bikube.newspaper.service
 
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
-import io.mockk.mockkStatic
 import io.mockk.verify
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -38,7 +37,6 @@ import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperTitleInputDto
 import no.nb.bikube.newspaper.NewspaperMockData.Companion.newspaperTitleMockB
 import no.nb.bikube.newspaper.repository.AxiellRepository
 import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
@@ -111,16 +109,8 @@ class AxiellServiceTest(
         partOfReference = newspaperItemMockB.catalogueId)
     )
 
-    @BeforeEach
-    fun beforeEach() {
-        mockkStatic(LocalTime::class)
-        every { LocalTime.now() } returns LocalTime.of(9, 30, 0)
-    }
-
     @Test
     fun `createTitle should return Title object with default values from Title with only name and materialType`() {
-        mockkStatic(LocalTime::class)
-        every { LocalTime.now() } returns LocalTime.of(9, 30, 0)
         every { axiellRepository.createTextsRecord(any()) } returns Mono.just(collectionsModelMockTitleE)
 
         val body = newspaperTitleInputDtoMockB.copy()
@@ -469,8 +459,6 @@ class AxiellServiceTest(
 
     @Test
     fun `createTitle should correctly encode the title object sent to json string`() {
-        mockkStatic(LocalTime::class)
-        every { LocalTime.now() } returns LocalTime.of(9, 30, 0)
         every { axiellRepository.createTextsRecord(any()) } returns Mono.just(collectionsModelMockTitleE)
         val encodedValue = Json.encodeToString(
             TitleDto(
@@ -703,8 +691,6 @@ class AxiellServiceTest(
 
     @Test
     fun `createManifestation should correctly encode the manifestation object sent to json string`() {
-        mockkStatic(LocalTime::class)
-        every { LocalTime.now() } returns LocalTime.of(9, 30, 0)
         every { axiellRepository.createTextsRecord(any()) } returns Mono.just(collectionsModelMockManifestationA)
         every { axiellRepository.getSingleCollectionsModel(any()) } returns Mono.just(collectionsModelMockManifestationA)
 
@@ -761,8 +747,6 @@ class AxiellServiceTest(
 
     @Test
     fun `createYearWork should correctly encode the year work object sent to json string`() {
-        mockkStatic(LocalTime::class)
-        every { LocalTime.now() } returns LocalTime.of(9, 30, 0)
         every { axiellRepository.createTextsRecord(any()) } returns Mono.just(collectionsModelMockYearWorkA)
         every { axiellRepository.getSingleCollectionsModel(any()) } returns Mono.just(collectionsModelMockYearWorkA)
 


### PR DESCRIPTION
Integration tests were failing depending on the order in which the test classes were run.
The cause was the use of a static mock on `LocalTime.now()`, in AxiellServiceTest, which influenced subsequent tests.
The solution was to restore this call to the actual method, with `unmockkStatic`.

Some comments:
- the runOrder random configuration in pom.xml is not needed, but makes our test suite stricter, which is why I kept it in
- reproducing the problem locally (in only one integration test class) worked (i.e. failed), see actions from reverted commit ("Test hypothesis")
- in AxiellServiceTest, it was unclear whether the shared objects (private val defined outside of test methods) were instantiated before or after the mockkStatic call. The new `mockedTime` variable solves this.