### PR TITLE
fix(newspaper): patch broken search function (TT-1465)

### DIFF
--- a/src/main/kotlin/no/nb/bikube/catalogue/collections/repository/CollectionsRepository.kt
+++ b/src/main/kotlin/no/nb/bikube/catalogue/collections/repository/CollectionsRepository.kt
@@ -25,6 +25,14 @@ class CollectionsRepository(
         return searchTexts("priref=${titleCatalogId}")
     }
 
+    fun getWorkYearForTitle(titleCatalogId: String, year: Int): Mono<CollectionsModel> {
+        return searchTexts(
+            "part_of_reference.lref=${titleCatalogId} and" +
+            "dating.date.start=${year} and" +
+            "work.description_type=${CollectionsDescriptionType.YEAR}"
+        )
+    }
+
     fun getTitleByName(name: String): Mono<CollectionsModel> {
         return searchTexts(
             "record_type=${CollectionsRecordType.WORK} and " +

--- a/src/main/kotlin/no/nb/bikube/catalogue/collections/repository/CollectionsRepository.kt
+++ b/src/main/kotlin/no/nb/bikube/catalogue/collections/repository/CollectionsRepository.kt
@@ -27,8 +27,8 @@ class CollectionsRepository(
 
     fun getWorkYearForTitle(titleCatalogId: String, year: Int): Mono<CollectionsModel> {
         return searchTexts(
-            "part_of_reference.lref=${titleCatalogId} and" +
-            "dating.date.start=${year} and" +
+            "part_of_reference.lref=${titleCatalogId} and " +
+            "dating.date.start=${year} and " +
             "work.description_type=${CollectionsDescriptionType.YEAR}"
         )
     }

--- a/src/test/kotlin/no/nb/bikube/catalogue/collections/CollectionsModelMockData.kt
+++ b/src/test/kotlin/no/nb/bikube/catalogue/collections/CollectionsModelMockData.kt
@@ -100,7 +100,7 @@ class CollectionsModelMockData {
                 workTypeList = null,
                 formatList = null,
                 partsList = null,
-                dateStart = null
+                dateStart = listOf(CollectionsDating(dateFrom = "2020-01-01", dateTo = null))
             )
         )
 
@@ -494,6 +494,87 @@ class CollectionsModelMockData {
 
         val collectionsNameModelWithEmptyRecordListA = CollectionsNameModel(
             adlibJson = CollectionsNameRecordList(recordList = null)
+        )
+
+        val collectionsModelMockYearWorkC = CollectionsModel(
+            adlibJson = CollectionsRecordList(
+                recordList = listOf(
+                    CollectionsObject(
+                        priRef = "30",
+                        titleList = listOf(CollectionsTitle(title = "Aftenposten")),
+                        recordTypeList = collectionsRecordTypeListWorkMock,
+                        formatList = null,
+                        partOfList = null,
+                        subMediumList = null,
+                        mediumList = null,
+                        datingList = listOf(CollectionsDating(dateFrom = "2020-01-01", dateTo = null)),
+                        publisherList = null,
+                        languageList = null,
+                        placeOfPublicationList = null,
+                        partsList = listOf(collectionsPartsObjectMockManifestationB),
+                        workTypeList = collectionsWorkTypeListYearMock,
+                        alternativeNumberList = null
+                    )
+                )
+            )
+        )
+
+        val collectionsPartsObjectMockItemD = CollectionsPartsObject(
+            partsReference = CollectionsPartsReference(
+                priRef = "32",
+                titleList = listOf(CollectionsTitle(title = "Aftenposten")),
+                recordType = collectionsRecordTypeListItemMock,
+                workTypeList = null,
+                formatList = collectionsFormatListDigitalMock,
+                partsList = null,
+                dateStart = null
+            )
+        )
+
+        val collectionsModelMockManifestationC = CollectionsModel(
+            adlibJson = CollectionsRecordList(
+                recordList = listOf(
+                    CollectionsObject(
+                        priRef = "31",
+                        titleList = listOf(CollectionsTitle(title = "Aftenposten")),
+                        recordTypeList = collectionsRecordTypeListManifestMock,
+                        formatList = null,
+                        partOfList = null,
+                        subMediumList = null,
+                        mediumList = null,
+                        datingList = null,
+                        publisherList = null,
+                        languageList = null,
+                        placeOfPublicationList = null,
+                        partsList = listOf(collectionsPartsObjectMockItemD),
+                        workTypeList = null,
+                        alternativeNumberList = null
+                    )
+                )
+            )
+        )
+
+        val yearWorkNoManifestationA = CollectionsModel(
+            adlibJson = CollectionsRecordList(
+                recordList = listOf(
+                    CollectionsObject(
+                        priRef = "100",
+                        titleList = listOf(CollectionsTitle(title = "Aftenposten")),
+                        recordTypeList = collectionsRecordTypeListWorkMock,
+                        formatList = null,
+                        partOfList = null,
+                        subMediumList = listOf(SubMedium(subMedium = "Aviser")),
+                        mediumList = null,
+                        datingList = listOf(CollectionsDating(dateFrom = "2024", dateTo = null)),
+                        publisherList = null,
+                        languageList = null,
+                        placeOfPublicationList = null,
+                        partsList = listOf(),
+                        workTypeList = collectionsWorkTypeListYearMock,
+                        alternativeNumberList = null,
+                    )
+                )
+            )
         )
     }
 }

--- a/src/test/kotlin/no/nb/bikube/core/controller/CoreControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nb/bikube/core/controller/CoreControllerIntegrationTest.kt
@@ -55,6 +55,7 @@ class CoreControllerIntegrationTest (
         every { collectionsRepository.getSingleCollectionsModel(manifestationId) } returns Mono.just(collectionsModelMockManifestationA.copy())
         every { collectionsRepository.getSingleCollectionsModel(itemId) } returns Mono.just(collectionsModelMockItemA.copy())
         every { collectionsRepository.getTitleByName(any()) } returns Mono.just(collectionsModelMockAllTitles.copy())
+        every { collectionsRepository.getWorkYearForTitle(any(), any()) } returns Mono.just(collectionsModelMockYearWorkA.copy())
     }
 
     private fun getItem(itemId: String, materialType: MaterialType): ResponseSpec {
@@ -443,7 +444,7 @@ class CoreControllerIntegrationTest (
 
     @Test
     fun `search-item endpoint should return empty flux when no items match search term`() {
-        every { collectionsRepository.getSingleCollectionsModel("no match") } returns Mono.just(collectionsModelEmptyRecordListMock.copy())
+        every { collectionsRepository.getWorkYearForTitle("no match", any()) } returns Mono.just(collectionsModelEmptyRecordListMock.copy())
 
         webClient
             .get()

--- a/src/test/kotlin/no/nb/bikube/newspaper/controller/ItemControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/controller/ItemControllerIntegrationTest.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.json.Json
 import no.nb.bikube.catalogue.collections.CollectionsModelMockData.Companion.collectionsModelEmptyRecordListMock
 import no.nb.bikube.catalogue.collections.CollectionsModelMockData.Companion.collectionsModelMockItemA
 import no.nb.bikube.catalogue.collections.CollectionsModelMockData.Companion.collectionsModelMockManifestationA
-import no.nb.bikube.catalogue.collections.CollectionsModelMockData.Companion.collectionsModelMockManifestationB
+import no.nb.bikube.catalogue.collections.CollectionsModelMockData.Companion.collectionsModelMockManifestationC
 import no.nb.bikube.catalogue.collections.CollectionsModelMockData.Companion.collectionsModelMockTitleA
 import no.nb.bikube.catalogue.collections.CollectionsModelMockData.Companion.collectionsModelMockTitleB
 import no.nb.bikube.catalogue.collections.CollectionsModelMockData.Companion.collectionsModelMockTitleC
@@ -49,7 +49,7 @@ class ItemControllerIntegrationTest (
 
     private val titleId = collectionsModelMockTitleA.getFirstId()!!
     private val yearWorkId = collectionsModelMockYearWorkA.getFirstId()!!
-    private val manifestationId = collectionsModelMockManifestationB.getFirstId()!!
+    private val manifestationId = collectionsModelMockManifestationC.getFirstId()!!
     private val itemId = collectionsModelMockItemA.getFirstId()!!
 
     private fun createItem(item: ItemInputDto): ResponseSpec {
@@ -78,7 +78,7 @@ class ItemControllerIntegrationTest (
             val dto = json.decodeFromString<DtoMock>(encodedBody.captured)
             when (dto.recordType) {
                 CollectionsRecordType.ITEM.value -> Mono.just(collectionsModelMockItemA)
-                CollectionsRecordType.MANIFESTATION.value -> Mono.just(collectionsModelMockManifestationB)
+                CollectionsRecordType.MANIFESTATION.value -> Mono.just(collectionsModelMockManifestationC)
                 CollectionsRecordType.WORK.value -> {
                     if (dto.descriptionType == CollectionsDescriptionType.SERIAL.value) {
                         Mono.just(collectionsModelMockTitleA)

--- a/src/test/kotlin/no/nb/bikube/newspaper/service/NewspaperServiceTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/service/NewspaperServiceTest.kt
@@ -785,6 +785,7 @@ class NewspaperServiceTest(
 
     @Test
     fun `searchItemByTitle should return correctly mapped item`() {
+        every { collectionsRepository.getWorkYearForTitle(any(), any()) } returns Mono.just(collectionsModelMockYearWorkA)
         every { collectionsRepository.getSingleCollectionsModel(any()) } returns Mono.just(collectionsModelMockTitleA)
         val expectedMock = collectionsPartsObjectMockItemA.copy().partsReference!!
         newspaperService.getItemsByTitle("1", LocalDate.parse("2020-01-01"), true, MaterialType.NEWSPAPER)
@@ -812,7 +813,7 @@ class NewspaperServiceTest(
 
     @Test
     fun `searchItemByTitle should return an empty flux if no items are found`() {
-        every { collectionsRepository.getSingleCollectionsModel(any()) } returns Mono.just(collectionsModelEmptyRecordListMock)
+        every { collectionsRepository.getWorkYearForTitle(any(), any()) } returns Mono.just(collectionsModelEmptyRecordListMock)
 
         newspaperService.getItemsByTitle("19", LocalDate.parse("1999-12-24"), true, MaterialType.NEWSPAPER)
             .test()
@@ -820,12 +821,12 @@ class NewspaperServiceTest(
             .expectNextCount(0)
             .verifyComplete()
 
-        verify { collectionsRepository.getSingleCollectionsModel("19") }
+        verify { collectionsRepository.getWorkYearForTitle("19", 1999) }
     }
 
     @Test
     fun `searchItemByTitle should return an empty flux if title has no year works on given year`() {
-        every { collectionsRepository.getSingleCollectionsModel(any()) } returns Mono.just(collectionsModelMockTitleB)
+        every { collectionsRepository.getWorkYearForTitle(any(), any()) } returns Mono.just(collectionsModelMockTitleB)
 
         newspaperService.getItemsByTitle("6", LocalDate.parse("2000-01-01"), true, MaterialType.NEWSPAPER)
             .test()
@@ -833,7 +834,7 @@ class NewspaperServiceTest(
             .expectNextCount(0)
             .verifyComplete()
 
-        verify { collectionsRepository.getSingleCollectionsModel("6") }
+        verify { collectionsRepository.getWorkYearForTitle("6", 2000) }
     }
 
     @Test


### PR DESCRIPTION
Original search function was broken as we no longer receive a deep enough parts tree to find the correct item. This fix makes an additional API call to remedy the change in the Collections API.