### PR TITLE
ci: deploy to kubernetes stage (TT-1455)

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -1,10 +1,10 @@
 name: CI/CD Pipeline
 
-on: [push]
+on: [push, workflow_dispatch]
 
 env:
   MAVEN_INFO: "--batch-mode -Pcoverage -Dmaven.repo.local=.m2/repository -Dbuild.tag=$GITHUB_REF_NAME -Dbuild.commit-id-short=$GITHUB_SHA -Dbuild.commit-id-long=$GITHUB_SHA -Dbuild.pipeline-id=$GITHUB_RUN_ID"
-
+  APP_VERSION: ${{ github.ref_name }}
 jobs:
   build-and-test:
     name: Build and Test
@@ -46,7 +46,7 @@ jobs:
     needs: build-and-test
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     name: Create and push Docker image
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -91,3 +91,43 @@ jobs:
           repository: nationallibraryofnorway/bikube
           short-description: ${{ github.event.repository.description }}
           readme-filepath: ./README.md
+
+  deploy-to-k8s-stage:
+    name: Deploy to kubernetes stage environment
+    needs: build-and-publish-docker-image
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: [self-hosted, Linux]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Import secrets
+        id: import-secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          url: ${{ secrets.VAULT_URL }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            kv/team/text/data/k8s-text-stage *
+
+      - name: Setup Kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: 'v1.26.5'
+
+      - name: Deploy to stage cluster
+        run: |
+          echo "Deploying to stage version ${{ env.APP_VERSION }}"
+          sed -i "s/<version>/${{ env.APP_VERSION }}/g" k8s/stage/bikube.yml
+          sed -i "s/<host_url>/${{ steps.import-secrets.outputs.K8S_HOST_URL }}/g" k8s/stage/bikube.yml
+          kubectl config set-cluster stagecl --server=${{ steps.import-secrets.outputs.K8S_STAGE_SERVER }}
+          kubectl config set clusters.stagecl.certificate-authority-data ${{ steps.import-secrets.outputs.K8S_STAGE_NB_NO_CA }}
+          kubectl config set-credentials ${{ steps.import-secrets.outputs.K8S_STAGE_USER }} --token=${{ steps.import-secrets.outputs.K8S_STAGE_NB_NO_TOKEN }}
+          kubectl config set-context tekst --cluster=stagecl --user=${{ steps.import-secrets.outputs.K8S_STAGE_USER }} --namespace=tekst-stage
+          kubectl config use-context tekst
+          kubectl config view
+          kubectl version
+          kubectl apply -f k8s/stage/bikube.yml
+          kubectl rollout restart deploy/bikube

--- a/k8s/stage/bikube.yml
+++ b/k8s/stage/bikube.yml
@@ -1,0 +1,140 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bikube
+  namespace: tekst-stage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bikube
+  template:
+    metadata:
+      labels:
+        app: bikube
+    spec:
+      priorityClassName: medium-priority
+      containers:
+        - name: app
+          image: nationallibraryofnorway/bikube:<version>
+          ports:
+            - name: app-port
+              containerPort: 8087
+            - name: actuator-port
+              containerPort: 8088
+          env:
+            - name: INFO_ENVIRONMENT
+              value: STAGE
+            - name: SPRING_PROFILES_ACTIVE
+              value: "stage"
+            - name: STAGE_BIKUBE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: bikube-secrets
+                  key: username
+            - name: STAGE_BIKUBE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: bikube-secrets
+                  key: password
+            - name: COLLECTIONS_PATH_STAGE
+              valueFrom:
+                secretKeyRef:
+                  name: bikube-secrets
+                  key: collections_url
+            - name: COLLECTIONS_USERNAME_STAGE
+              valueFrom:
+                secretKeyRef:
+                  name: bikube-secrets
+                  key: ad_username
+            - name: COLLECTIONS_PASSWORD_STAGE
+              valueFrom:
+                secretKeyRef:
+                  name: bikube-secrets
+                  key: ad_password
+            - name: KERBEROS_REALM
+              valueFrom:
+                secretKeyRef:
+                  name: bikube-secrets
+                  key: kerb_realm
+            - name: KERBEROS_KDC
+              valueFrom:
+                secretKeyRef:
+                  name: bikube-secrets
+                  key: kerb_kdc
+            - name: ALMAWS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: bikube-secrets
+                  key: alma_url
+            - name: ALMA_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: bikube-secrets
+                  key: alma_api_key
+            - name: HTTP_PROXY_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: bikube-secrets
+                  key: http_proxy_host
+            - name: HTTP_PROXY_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: bikube-secrets
+                  key: http_proxy_port
+          imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: actuator-port
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            failureThreshold: 3
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: actuator-port
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            failureThreshold: 3
+            timeoutSeconds: 1
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: bikube
+spec:
+  ports:
+    - port: 8087
+      name: rest
+      targetPort: 8087
+    - port: 8088
+      name: http
+      targetPort: 8088
+  selector:
+    app: bikube
+  type: ClusterIP
+
+---
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: bikube-ingress
+  namespace: tekst-stage
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: <host_url>
+      http:
+        paths:
+          - backend:
+              service:
+                name: bikube
+                port:
+                  number: 8087
+            path: /bikube
+            pathType: Prefix


### PR DESCRIPTION
Denne PRen legger til utrulling i staging-miljøet i Kubernetes. Secrets hentes fra Vault, ellers er oppsettet ganske likt som det gamle i GitLab.

Usikker på hvordan manuell trigger av pipeline blir å fungere i praksis, virker ikke like rett frem som det vi er vant med.