### PR TITLE
feat: limit item creation to max one of each format for every manifestation (TT-1735)

### DIFF
--- a/src/main/kotlin/no/nb/bikube/catalogue/collections/controller/CollectionsControllerExceptionHandler.kt
+++ b/src/main/kotlin/no/nb/bikube/catalogue/collections/controller/CollectionsControllerExceptionHandler.kt
@@ -65,4 +65,15 @@ class CollectionsControllerExceptionHandler {
 
         return problemDetail
     }
+
+    @ExceptionHandler(CollectionsManifestationItemsAlreadyExist::class)
+    fun handleCollectionsManifestationItemsAlreadyExistException(exception: CollectionsManifestationItemsAlreadyExist): ProblemDetail {
+        logger().warn("CollectionsManifestationItemsAlreadyExist occurred: ${exception.message}")
+
+        val problemDetail = ProblemDetail.forStatus(HttpStatus.CONFLICT)
+        problemDetail.detail = "Collections manifestation items already exist: ${exception.message}"
+        problemDetail.addDefaultProperties()
+
+        return problemDetail
+    }
 }

--- a/src/main/kotlin/no/nb/bikube/catalogue/collections/exception/CollectionsManifestationItemsAlreadyExist.kt
+++ b/src/main/kotlin/no/nb/bikube/catalogue/collections/exception/CollectionsManifestationItemsAlreadyExist.kt
@@ -1,0 +1,3 @@
+package no.nb.bikube.catalogue.collections.exception
+
+class CollectionsManifestationItemsAlreadyExist (message: String?): CollectionsException(message)

--- a/src/main/kotlin/no/nb/bikube/newspaper/controller/ItemController.kt
+++ b/src/main/kotlin/no/nb/bikube/newspaper/controller/ItemController.kt
@@ -31,6 +31,7 @@ class ItemController (
     @ApiResponses(value = [
         ApiResponse(responseCode = "201", description = "Newspaper created"),
         ApiResponse(responseCode = "400", description = "Bad request", content = [Content()]),
+        ApiResponse(responseCode = "409", description = "Conflict", content = [Content()]),
         ApiResponse(responseCode = "500", description = "Server error", content = [Content()])
     ])
     fun createItem(

--- a/src/test/kotlin/no/nb/bikube/newspaper/controller/ItemControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/controller/ItemControllerIntegrationTest.kt
@@ -11,6 +11,7 @@ import no.nb.bikube.catalogue.collections.CollectionsModelMockData.Companion.col
 import no.nb.bikube.catalogue.collections.CollectionsModelMockData.Companion.collectionsModelMockManifestationB
 import no.nb.bikube.catalogue.collections.CollectionsModelMockData.Companion.collectionsModelMockManifestationC
 import no.nb.bikube.catalogue.collections.CollectionsModelMockData.Companion.collectionsModelMockManifestationD
+import no.nb.bikube.catalogue.collections.CollectionsModelMockData.Companion.collectionsModelMockManifestationE
 import no.nb.bikube.catalogue.collections.CollectionsModelMockData.Companion.collectionsModelMockTitleA
 import no.nb.bikube.catalogue.collections.CollectionsModelMockData.Companion.collectionsModelMockTitleB
 import no.nb.bikube.catalogue.collections.CollectionsModelMockData.Companion.collectionsPartOfObjectMockSerialWorkA
@@ -164,13 +165,27 @@ class ItemControllerIntegrationTest {
 
     @Test
     fun `post-newspapers-items endpoint should create correct manifestation if not found`() {
+        val item = newspaperItemMockCValidForCreation.copy(date = LocalDate.parse("2000-01-01"))
+
         every { collectionsRepository.getSingleCollectionsModel(titleId) } returns Mono.just(collectionsModelMockTitleB.copy())
+        every { collectionsRepository.getSingleCollectionsModel(item.titleCatalogueId) } returns Mono.just(collectionsModelMockTitleB.copy())
+        every { collectionsRepository.getSingleCollectionsModel(any()) } returns Mono.just(collectionsModelMockManifestationE.copy())
         every { collectionsRepository.getManifestations(any(), any(), any()) } returns Mono.just(collectionsModelEmptyRecordListMock)
 
-        createItem(newspaperItemMockCValidForCreation.copy(date = LocalDate.parse("2000-01-01")))
+        createItem(item)
             .expectStatus().isCreated
 
         verify(exactly = 2) { collectionsRepository.createTextsRecord(any()) }
+    }
+
+    @Test
+    fun `post-newspaper-items endpoint should return 409 conflict if manifestation already has item with given format`() {
+        every { collectionsRepository.getManifestations(any(), any(), any()) } returns Mono.just(collectionsModelMockManifestationD)
+
+        createItem(newspaperItemMockCValidForCreation)
+            .expectStatus().isEqualTo(409)
+
+        verify(exactly = 0) { collectionsRepository.createTextsRecord(any()) }
     }
 
     @Test

--- a/src/test/kotlin/no/nb/bikube/newspaper/controller/ItemControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/controller/ItemControllerIntegrationTest.kt
@@ -180,12 +180,15 @@ class ItemControllerIntegrationTest {
 
     @Test
     fun `post-newspaper-items endpoint should return 409 conflict if manifestation already has item with given format`() {
-        every { collectionsRepository.getManifestations(any(), any(), any()) } returns Mono.just(collectionsModelMockManifestationD)
+        val item = newspaperItemMockCValidForCreation.copy(date = LocalDate.parse("2000-01-01"))
 
-        createItem(newspaperItemMockCValidForCreation)
+        every { collectionsRepository.getSingleCollectionsModel(titleId) } returns Mono.just(collectionsModelMockTitleB.copy())
+        every { collectionsRepository.getSingleCollectionsModel(item.titleCatalogueId) } returns Mono.just(collectionsModelMockTitleB.copy())
+        every { collectionsRepository.getSingleCollectionsModel(any()) } returns Mono.just(collectionsModelMockManifestationA.copy())
+        every { collectionsRepository.getManifestations(any(), any(), any()) } returns Mono.just(collectionsModelMockManifestationA.copy())
+
+        createItem(item)
             .expectStatus().isEqualTo(409)
-
-        verify(exactly = 0) { collectionsRepository.createTextsRecord(any()) }
     }
 
     @Test

--- a/src/test/kotlin/no/nb/bikube/newspaper/service/NewspaperServiceTest.kt
+++ b/src/test/kotlin/no/nb/bikube/newspaper/service/NewspaperServiceTest.kt
@@ -471,6 +471,7 @@ class NewspaperServiceTest {
         every { collectionsRepository.createTextsRecord(any()) } returns Mono.just(collectionsModelMockItemB)
         every { collectionsRepository.getSingleCollectionsModelWithoutChildren(any()) } returns Mono.just(collectionsModelMockItemB)
         every { collectionsRepository.getManifestations(any(), any(), any()) } returns Mono.just(collectionsModelMockManifestationB)
+        every { collectionsRepository.getSingleCollectionsModel(any()) } returns Mono.just(collectionsModelMockItemB)
 
         newspaperService.createNewspaperItem(newspaperInputDtoItemMockB)
             .test()
@@ -485,6 +486,7 @@ class NewspaperServiceTest {
         every { collectionsRepository.createTextsRecord(manifestationEncodedDto) } returns Mono.just(collectionsModelMockItemB)
         every { collectionsRepository.getSingleCollectionsModelWithoutChildren(any()) } returns Mono.just(collectionsModelMockItemB)
         every { collectionsRepository.getManifestations(any(), any(), any()) } returns Mono.just(collectionsModelMockManifestationB)
+        every { collectionsRepository.getSingleCollectionsModel(any()) } returns Mono.just(collectionsModelMockItemB)
 
         newspaperService.createNewspaperItem(newspaperInputDtoItemMockB)
             .test()
@@ -499,6 +501,7 @@ class NewspaperServiceTest {
     fun `createNewspaperItem should throw CollectionsItemNotFound if item could not be found`() {
         every { collectionsRepository.createTextsRecord(itemEncodedDto) } returns Mono.just(collectionsModelEmptyRecordListMock)
         every { collectionsRepository.createTextsRecord(manifestationEncodedDto) } returns Mono.just(collectionsModelMockItemB)
+        every { collectionsRepository.getSingleCollectionsModel(any()) } returns Mono.just(collectionsModelMockItemB)
         every { collectionsRepository.getSingleCollectionsModelWithoutChildren(any()) } returns Mono.just(collectionsModelMockItemB)
         every { collectionsRepository.getManifestations(any(), any(), any()) } returns Mono.just(collectionsModelMockManifestationB)
 
@@ -515,6 +518,7 @@ class NewspaperServiceTest {
     @Test
     fun `createNewspaperItem should ignore URN if is is a physical item`() {
         every { collectionsRepository.createTextsRecord(any()) } returns Mono.just(collectionsModelMockItemB)
+        every { collectionsRepository.getSingleCollectionsModel(any()) } returns Mono.just(collectionsModelMockItemB)
         every { collectionsRepository.getSingleCollectionsModelWithoutChildren(any()) } returns Mono.just(collectionsModelMockItemB)
         every { collectionsRepository.getManifestations(any(), any(), any()) } returns Mono.just(collectionsModelMockManifestationB)
         newspaperService.createNewspaperItem(newspaperInputDtoItemMockB.copy(digital = false))
@@ -529,6 +533,7 @@ class NewspaperServiceTest {
     @Test
     fun `createNewspaperItem should get or create container if item is physical and has container ID`() {
         every { collectionsRepository.getSingleCollectionsModelWithoutChildren(any()) } returns Mono.just(collectionsModelMockItemB)
+        every { collectionsRepository.getSingleCollectionsModel(any()) } returns Mono.just(collectionsModelMockItemB)
         every { collectionsRepository.getManifestations(any(), any(), any()) } returns Mono.just(collectionsModelMockManifestationB)
         every { collectionLocationService.createContainerIfNotExists(any(), any()) } returns Mono.just(collectionsLocationObjectMock)
         every { collectionsRepository.createTextsRecord(any()) } returns Mono.just(collectionsModelMockItemB)
@@ -551,6 +556,7 @@ class NewspaperServiceTest {
     @Test
     fun `createNewspaperItem should not get or create container if item is digital`() {
         every { collectionsRepository.getSingleCollectionsModelWithoutChildren(any()) } returns Mono.just(collectionsModelMockItemB)
+        every { collectionsRepository.getSingleCollectionsModel(any()) } returns Mono.just(collectionsModelMockItemB)
         every { collectionsRepository.getManifestations(any(), any(), any()) } returns Mono.just(collectionsModelMockManifestationB)
         every { collectionsRepository.createTextsRecord(any()) } returns Mono.just(collectionsModelMockItemB)
 
@@ -571,6 +577,7 @@ class NewspaperServiceTest {
     @Test
     fun `createNewspaperItem should not get or create container if item is physical and does not have container ID`() {
         every { collectionsRepository.getSingleCollectionsModelWithoutChildren(any()) } returns Mono.just(collectionsModelMockItemB)
+        every { collectionsRepository.getSingleCollectionsModel(any()) } returns Mono.just(collectionsModelMockItemB)
         every { collectionsRepository.getManifestations(any(), any(), any()) } returns Mono.just(collectionsModelMockManifestationB)
         every { collectionsRepository.createTextsRecord(any()) } returns Mono.just(collectionsModelMockItemB)
 


### PR DESCRIPTION
Legger på begrensning for maks en fysisk og maks en digital utgave på en manifestasjon når man oppretter en manifestasjon.